### PR TITLE
init: fixed non-repsonsive UI bug in windows' execution

### DIFF
--- a/init/unix.sh
+++ b/init/unix.sh
@@ -351,12 +351,13 @@ Output Extension : $__output_format
         if [ $video_mode -eq 0 ]; then
                 output="${subject_dir}/${subject_name}-${subject_suffix}.${format}"
                 _exec_upscale_program "$input" "$output"
-
-                output=$?
-                if [ $output -eq 0 ]; then
+                if [ $? -eq 0 ]; then
                         _print_status success "\n"
+                        exit 0
                 fi
-                return $?
+
+                _print_status error
+                exit 1
         fi
 
         # (2) setup video workspace


### PR DESCRIPTION
Appearently, PowerShell does not have a way to stream its feedbacks to the main terminal while the binary execution output important data like progress status and graphics card information. Hence, we don't have a choice but to let it open a new window every single time. Let's fix it.

This patch fixed a non-responsive UI bug in windows' execution inside init/ directory.