### PR TITLE
README.md: fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ In case you need to contribute back:
 ## Benchmarks
 Results of benchmarks running `tests/benchmark.sh` at the root of the
 repository. Please leave the system dedicated to only running the benchmark
-and not doing something else for maintaining consistencies.
+and not doing something else for maintaining results consistencies.
 
 
 ### Debian AMD64 CPU, 12GB Memory, 2GB VRAM, NVIDIA GeForce MX150


### PR DESCRIPTION
There were some typo spotted by Cory. Hence, we need to fix it.

This patch fixes typo in README.md.