### PR TITLE
.configs/monteur: added repo clean up CI jobs

### DIFF
--- a/.configs/monteur/clean/jobs/build-log.toml
+++ b/.configs/monteur/clean/jobs/build-log.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Build Log Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'build'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/log/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/build-tmp.toml
+++ b/.configs/monteur/clean/jobs/build-tmp.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Build TMP Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'build'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Path = '{{- .RootDir -}}/{{- .MonteurPath -}}/tmp/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Recursively"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Path -}}'
+
+[[CMD]]
+Name = "Re-Create Target for Restoration"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Path -}}'

--- a/.configs/monteur/clean/jobs/compose-log.toml
+++ b/.configs/monteur/clean/jobs/compose-log.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Compose Log Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'compose'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/log/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/compose-tmp.toml
+++ b/.configs/monteur/clean/jobs/compose-tmp.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Compose TMP Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'compose'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/tmp/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/hestiaDOCS.toml
+++ b/.configs/monteur/clean/jobs/hestiaDOCS.toml
@@ -1,0 +1,29 @@
+[Metadata]
+Name = 'Clean Up Known Hestia Documentation Artifacts'
+Description = """
+Clean up all artifacts for Hestia documentation directory.
+"""
+
+
+
+
+[Variables]
+
+
+[FMTVariables]
+Directory = '{{- .RootDir -}}/docs'
+
+
+
+
+[[CMD]]
+Name = "Remove Target Recursively"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Directory -}}/resources'
+
+[[CMD]]
+Name = "Remove Target Recursively"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Directory -}}/.hugo_build.lock'

--- a/.configs/monteur/clean/jobs/package-log.toml
+++ b/.configs/monteur/clean/jobs/package-log.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Package Log Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'package'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/log/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/package-tmp.toml
+++ b/.configs/monteur/clean/jobs/package-tmp.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Package TMP Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'package'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/tmp/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/prepare-log.toml
+++ b/.configs/monteur/clean/jobs/prepare-log.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Prepare Log Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'prepare'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/log/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/prepare-tmp.toml
+++ b/.configs/monteur/clean/jobs/prepare-tmp.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Prepare TMP Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'prepare'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/tmp/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/publish-log.toml
+++ b/.configs/monteur/clean/jobs/publish-log.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Publish Log Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'publish'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/log/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/publish-tmp.toml
+++ b/.configs/monteur/clean/jobs/publish-tmp.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Publish TMP Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'publish'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/tmp/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/release-log.toml
+++ b/.configs/monteur/clean/jobs/release-log.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Release Log Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'release'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/log/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/releases.toml
+++ b/.configs/monteur/clean/jobs/releases.toml
@@ -1,0 +1,23 @@
+[Metadata]
+Name = 'Clean Up Known Hestia Releases Artifacts'
+Description = """
+Clean up all artifacts for Hestia releases directory.
+"""
+
+
+
+
+[Variables]
+
+
+[FMTVariables]
+Directory = '{{- .RootDir -}}/releases'
+
+
+
+
+[[CMD]]
+Name = "Remove Target Recursively"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Directory -}}'

--- a/.configs/monteur/clean/jobs/setup-log.toml
+++ b/.configs/monteur/clean/jobs/setup-log.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Setup Log Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'setup'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/log/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/setup-tmp.toml
+++ b/.configs/monteur/clean/jobs/setup-tmp.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Setup TMP Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'setup'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/tmp/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/test-log.toml
+++ b/.configs/monteur/clean/jobs/test-log.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Test Log Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'test'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/log/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'

--- a/.configs/monteur/clean/jobs/test-tmp.toml
+++ b/.configs/monteur/clean/jobs/test-tmp.toml
@@ -1,0 +1,27 @@
+[Metadata]
+Name = 'Clean Up Test TMP Artifacts'
+Description = """
+Clean up all artifacts for a job.
+"""
+
+[Variables]
+Job = 'test'
+MonteurPath = '.monteurFS'
+
+
+[FMTVariables]
+Target = '{{- .RootDir -}}/{{- .MonteurPath -}}/tmp/{{- .Job -}}'
+
+
+
+[[CMD]]
+Name = "Remove Target Directory"
+Type = 'delete-recursive-quiet'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'
+
+[[CMD]]
+Name = "Create Target Directory"
+Type = 'create-path'
+Condition = [ 'all-all' ]
+Source = '{{- .Target -}}'


### PR DESCRIPTION
Since the ZORALab's Monteur is ready, we can proceed to add clean up CI jobs into it. Hence, let's do this.

This patch adds repo clean up CI jobs in .configs/monteur/ directory.