### PR TITLE
.configs/monteur: added VERSION file into packager

### DIFF
--- a/.configs/monteur/package/jobs/zip-models.toml
+++ b/.configs/monteur/package/jobs/zip-models.toml
@@ -74,6 +74,14 @@ Target = '{{- .PackageDir -}}/models'
 
 
 [[CMD]]
+Name = 'Copy VERSION to target'
+Type = 'copy'
+Condition = [ 'all-all' ]
+Source = '{{- .RootDir -}}/VERSION'
+Target = '{{- .PackageDir -}}/VERSION'
+
+
+[[CMD]]
 Name = 'Copy LICENSE.TXT to target'
 Type = 'copy'
 Condition = [ 'all-all' ]

--- a/.configs/monteur/package/jobs/zip-tests.toml
+++ b/.configs/monteur/package/jobs/zip-tests.toml
@@ -108,6 +108,14 @@ Target = '{{- .PackageDir -}}/tests/video/sample-1-640x360.mp4'
 
 
 [[CMD]]
+Name = 'Copy VERSION to target'
+Type = 'copy'
+Condition = [ 'all-all' ]
+Source = '{{- .RootDir -}}/VERSION'
+Target = '{{- .PackageDir -}}/VERSION'
+
+
+[[CMD]]
 Name = 'Copy LICENSE.TXT to target'
 Type = 'copy'
 Condition = [ 'all-all' ]

--- a/.configs/monteur/package/jobs/zip-upscaler.toml
+++ b/.configs/monteur/package/jobs/zip-upscaler.toml
@@ -95,6 +95,14 @@ Target = '{{- .PackageDir -}}/models'
 
 
 [[CMD]]
+Name = 'Copy VERSION to target'
+Type = 'copy'
+Condition = [ 'all-all' ]
+Source = '{{- .RootDir -}}/VERSION'
+Target = '{{- .PackageDir -}}/VERSION'
+
+
+[[CMD]]
 Name = 'Copy LICENSE.TXT to target'
 Type = 'copy'
 Condition = [ 'all-all' ]


### PR DESCRIPTION
To make sure each release package has a known version indicator, we have to include the VERSION file into each packagers' job recipe. Otherwise, we're going to look for trouble with miscommunicatiosn. Hence, let's do this.

This patch adds VERSION file into packager in .configs/monteur/ directory.