### PR TITLE
README.md: corrected typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ $ git clone https://github.com/hollowaykeanho/Upscaler.git
 ```
 
 
-### Setup Pathing for Comamnd Calls [OPTIONAL, 1-Time]
+### Setup Pathing for Command [OPTIONAL, 1-Time]
 We advise you to symlink the `start.cmd` into `$PATH` or `%PATH%` directory
 depending on your operating system. Example, on `Debian Linux`:
 


### PR DESCRIPTION
There was a typo in the previous patch for installation instruction. Hence, we need to correct it.

This patch corrects typo in README.md.