### PR TITLE
start.cmd: fixed execution policy restriction due to accidental removal.

### DIFF
--- a/start.cmd
+++ b/start.cmd
@@ -58,13 +58,13 @@ set _parameters=%*
 set _parameters=!_parameters:--=-!
 set _parameters=!_parameters:input=path!
 set _parameters=!_parameters:"=\"!
-call Powershell.exe -NoProfile -Command "& '%location%' %_parameters%"
+call Powershell.exe -NoProfile -executionpolicy bypass -Command "& '%location%' %_parameters%"
 EXIT /B
 
 :empty
 set location=%~dp0init\windows.ps1
 set location="%location%"
-call Powershell.exe -NoProfile -Command "& '%location%'"
+call Powershell.exe -NoProfile -executionpolicy bypass -Command "& '%location%'"
 ::##############################################################################
 :: Windows Main Codes                                                          #
 ::##############################################################################


### PR DESCRIPTION
For some reason, commit d64c62f5de7f5f55c87432de601d688f11d144fe accidentally removed the bypass execution policy causing an immediate denial of use in new Windows system. Hence, we need to restore it back.

This patch restores and fixes execution policy restriction due to accidental removal in the previous patch.

Reported-by: Shuralyov, Jean <jean.shuralyov@proton.me>