### PR TITLE
README.md: added MSFT C++ dependency notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ reassembling a video file.
 You can proceed to install them in 1 go at: https://ffmpeg.org/
 
 
+#### Windows User
+You need to install Microsoft Visual C++ Redistributable Package from their
+[official website](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)
+if you haven't do so. Usually other software may automatically include a version
+installed already. Please check your "Add/Remove Program" control panel to
+verify.
+
+
 
 
 ## User Manual


### PR DESCRIPTION
Jean discovered that the binary depends on an external MSFT C++ dependency on a clean slate laptop. We did not discover it before since this dependency is usually installed automatically by other software using it. Hence, let's add a note into the README.md.

This patch adds MSFT C++ dependency notice into README.md.

Reported-by: Joly0 <13993216+Joly0@users.noreply.github.com>