### PR TITLE
init: upgraded unix.sh to allow parallel processing

### DIFF
--- a/tests/benchmark.cmd
+++ b/tests/benchmark.cmd
@@ -43,11 +43,12 @@ rm -rf ./tests/video/sample-1-640x360-upscaled_workspace &> /dev/null
 rm -rf ./tests/video/sample-1-640x360-upscaled.mp4 &> /dev/null
 start="$(date +%s)"
 ./start.cmd \
-	--model upscayl-ultrasharp-v2 \
-	--scale 4 \
-	--format webp \
-	--video \
-	--input tests/video/sample-1-640x360.mp4
+        --model upscayl-ultrasharp-v2 \
+        --scale 4 \
+        --format webp \
+        --video \
+        --parallel 1 \
+        --input tests/video/sample-1-640x360.mp4
 end="$(date +%s)"
 printf "Elapsed time: $(($end - $start)) seconds.\n"
 ################################################################################


### PR DESCRIPTION
Since there are demands for controlled parallel processing, we should implement the feature. Hence, let's start with the UNIX system first.

This patch upgrades unix.sh to permit controlled parallel processing in init/ directory.