### PR TITLE
models: added upscayl-nmkd-4x-superscale-sd-178000-g

### DIFF
--- a/models/upscayl-nmkd-4x-superscale-sd-178000-g.param
+++ b/models/upscayl-nmkd-4x-superscale-sd-178000-g.param
@@ -1,0 +1,1001 @@
+7767517
+999 1782
+Input            input.1                  0 1 data
+Convolution      Conv_0                   1 1 data 703 0=64 1=3 4=1 5=1 6=1728
+Split            splitncnn_0              1 8 703 703_splitncnn_0 703_splitncnn_1 703_splitncnn_2 703_splitncnn_3 703_splitncnn_4 703_splitncnn_5 703_splitncnn_6 703_splitncnn_7
+Convolution      Conv_1                   1 1 703_splitncnn_7 705 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_1              1 4 705 705_splitncnn_0 705_splitncnn_1 705_splitncnn_2 705_splitncnn_3
+Concat           Concat_3                 2 1 703_splitncnn_6 705_splitncnn_3 706
+Convolution      Conv_4                   1 1 706 708 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_2              1 3 708 708_splitncnn_0 708_splitncnn_1 708_splitncnn_2
+Concat           Concat_6                 3 1 703_splitncnn_5 705_splitncnn_2 708_splitncnn_2 709
+Convolution      Conv_7                   1 1 709 711 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_3              1 2 711 711_splitncnn_0 711_splitncnn_1
+Concat           Concat_9                 4 1 703_splitncnn_4 705_splitncnn_1 708_splitncnn_1 711_splitncnn_1 712
+Convolution      Conv_10                  1 1 712 714 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_12                5 1 703_splitncnn_3 705_splitncnn_0 708_splitncnn_0 711_splitncnn_0 714 715
+Convolution      Conv_13                  1 1 715 716 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_16                   2 1 716 703_splitncnn_2 719 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_4              1 6 719 719_splitncnn_0 719_splitncnn_1 719_splitncnn_2 719_splitncnn_3 719_splitncnn_4 719_splitncnn_5
+Convolution      Conv_17                  1 1 719_splitncnn_5 721 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_5              1 4 721 721_splitncnn_0 721_splitncnn_1 721_splitncnn_2 721_splitncnn_3
+Concat           Concat_19                2 1 719_splitncnn_4 721_splitncnn_3 722
+Convolution      Conv_20                  1 1 722 724 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_6              1 3 724 724_splitncnn_0 724_splitncnn_1 724_splitncnn_2
+Concat           Concat_22                3 1 719_splitncnn_3 721_splitncnn_2 724_splitncnn_2 725
+Convolution      Conv_23                  1 1 725 727 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_7              1 2 727 727_splitncnn_0 727_splitncnn_1
+Concat           Concat_25                4 1 719_splitncnn_2 721_splitncnn_1 724_splitncnn_1 727_splitncnn_1 728
+Convolution      Conv_26                  1 1 728 730 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_28                5 1 719_splitncnn_1 721_splitncnn_0 724_splitncnn_0 727_splitncnn_0 730 731
+Convolution      Conv_29                  1 1 731 732 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_32                   2 1 732 719_splitncnn_0 735 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_8              1 6 735 735_splitncnn_0 735_splitncnn_1 735_splitncnn_2 735_splitncnn_3 735_splitncnn_4 735_splitncnn_5
+Convolution      Conv_33                  1 1 735_splitncnn_5 737 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_9              1 4 737 737_splitncnn_0 737_splitncnn_1 737_splitncnn_2 737_splitncnn_3
+Concat           Concat_35                2 1 735_splitncnn_4 737_splitncnn_3 738
+Convolution      Conv_36                  1 1 738 740 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_10             1 3 740 740_splitncnn_0 740_splitncnn_1 740_splitncnn_2
+Concat           Concat_38                3 1 735_splitncnn_3 737_splitncnn_2 740_splitncnn_2 741
+Convolution      Conv_39                  1 1 741 743 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_11             1 2 743 743_splitncnn_0 743_splitncnn_1
+Concat           Concat_41                4 1 735_splitncnn_2 737_splitncnn_1 740_splitncnn_1 743_splitncnn_1 744
+Convolution      Conv_42                  1 1 744 746 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_44                5 1 735_splitncnn_1 737_splitncnn_0 740_splitncnn_0 743_splitncnn_0 746 747
+Convolution      Conv_45                  1 1 747 748 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_48                   2 1 748 735_splitncnn_0 751 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_51                   2 1 751 703_splitncnn_1 754 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_12             1 7 754 754_splitncnn_0 754_splitncnn_1 754_splitncnn_2 754_splitncnn_3 754_splitncnn_4 754_splitncnn_5 754_splitncnn_6
+Convolution      Conv_52                  1 1 754_splitncnn_6 756 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_13             1 4 756 756_splitncnn_0 756_splitncnn_1 756_splitncnn_2 756_splitncnn_3
+Concat           Concat_54                2 1 754_splitncnn_5 756_splitncnn_3 757
+Convolution      Conv_55                  1 1 757 759 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_14             1 3 759 759_splitncnn_0 759_splitncnn_1 759_splitncnn_2
+Concat           Concat_57                3 1 754_splitncnn_4 756_splitncnn_2 759_splitncnn_2 760
+Convolution      Conv_58                  1 1 760 762 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_15             1 2 762 762_splitncnn_0 762_splitncnn_1
+Concat           Concat_60                4 1 754_splitncnn_3 756_splitncnn_1 759_splitncnn_1 762_splitncnn_1 763
+Convolution      Conv_61                  1 1 763 765 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_63                5 1 754_splitncnn_2 756_splitncnn_0 759_splitncnn_0 762_splitncnn_0 765 766
+Convolution      Conv_64                  1 1 766 767 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_67                   2 1 767 754_splitncnn_1 770 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_16             1 6 770 770_splitncnn_0 770_splitncnn_1 770_splitncnn_2 770_splitncnn_3 770_splitncnn_4 770_splitncnn_5
+Convolution      Conv_68                  1 1 770_splitncnn_5 772 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_17             1 4 772 772_splitncnn_0 772_splitncnn_1 772_splitncnn_2 772_splitncnn_3
+Concat           Concat_70                2 1 770_splitncnn_4 772_splitncnn_3 773
+Convolution      Conv_71                  1 1 773 775 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_18             1 3 775 775_splitncnn_0 775_splitncnn_1 775_splitncnn_2
+Concat           Concat_73                3 1 770_splitncnn_3 772_splitncnn_2 775_splitncnn_2 776
+Convolution      Conv_74                  1 1 776 778 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_19             1 2 778 778_splitncnn_0 778_splitncnn_1
+Concat           Concat_76                4 1 770_splitncnn_2 772_splitncnn_1 775_splitncnn_1 778_splitncnn_1 779
+Convolution      Conv_77                  1 1 779 781 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_79                5 1 770_splitncnn_1 772_splitncnn_0 775_splitncnn_0 778_splitncnn_0 781 782
+Convolution      Conv_80                  1 1 782 783 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_83                   2 1 783 770_splitncnn_0 786 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_20             1 6 786 786_splitncnn_0 786_splitncnn_1 786_splitncnn_2 786_splitncnn_3 786_splitncnn_4 786_splitncnn_5
+Convolution      Conv_84                  1 1 786_splitncnn_5 788 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_21             1 4 788 788_splitncnn_0 788_splitncnn_1 788_splitncnn_2 788_splitncnn_3
+Concat           Concat_86                2 1 786_splitncnn_4 788_splitncnn_3 789
+Convolution      Conv_87                  1 1 789 791 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_22             1 3 791 791_splitncnn_0 791_splitncnn_1 791_splitncnn_2
+Concat           Concat_89                3 1 786_splitncnn_3 788_splitncnn_2 791_splitncnn_2 792
+Convolution      Conv_90                  1 1 792 794 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_23             1 2 794 794_splitncnn_0 794_splitncnn_1
+Concat           Concat_92                4 1 786_splitncnn_2 788_splitncnn_1 791_splitncnn_1 794_splitncnn_1 795
+Convolution      Conv_93                  1 1 795 797 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_95                5 1 786_splitncnn_1 788_splitncnn_0 791_splitncnn_0 794_splitncnn_0 797 798
+Convolution      Conv_96                  1 1 798 799 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_99                   2 1 799 786_splitncnn_0 802 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_102                  2 1 802 754_splitncnn_0 805 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_24             1 7 805 805_splitncnn_0 805_splitncnn_1 805_splitncnn_2 805_splitncnn_3 805_splitncnn_4 805_splitncnn_5 805_splitncnn_6
+Convolution      Conv_103                 1 1 805_splitncnn_6 807 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_25             1 4 807 807_splitncnn_0 807_splitncnn_1 807_splitncnn_2 807_splitncnn_3
+Concat           Concat_105               2 1 805_splitncnn_5 807_splitncnn_3 808
+Convolution      Conv_106                 1 1 808 810 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_26             1 3 810 810_splitncnn_0 810_splitncnn_1 810_splitncnn_2
+Concat           Concat_108               3 1 805_splitncnn_4 807_splitncnn_2 810_splitncnn_2 811
+Convolution      Conv_109                 1 1 811 813 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_27             1 2 813 813_splitncnn_0 813_splitncnn_1
+Concat           Concat_111               4 1 805_splitncnn_3 807_splitncnn_1 810_splitncnn_1 813_splitncnn_1 814
+Convolution      Conv_112                 1 1 814 816 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_114               5 1 805_splitncnn_2 807_splitncnn_0 810_splitncnn_0 813_splitncnn_0 816 817
+Convolution      Conv_115                 1 1 817 818 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_118                  2 1 818 805_splitncnn_1 821 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_28             1 6 821 821_splitncnn_0 821_splitncnn_1 821_splitncnn_2 821_splitncnn_3 821_splitncnn_4 821_splitncnn_5
+Convolution      Conv_119                 1 1 821_splitncnn_5 823 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_29             1 4 823 823_splitncnn_0 823_splitncnn_1 823_splitncnn_2 823_splitncnn_3
+Concat           Concat_121               2 1 821_splitncnn_4 823_splitncnn_3 824
+Convolution      Conv_122                 1 1 824 826 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_30             1 3 826 826_splitncnn_0 826_splitncnn_1 826_splitncnn_2
+Concat           Concat_124               3 1 821_splitncnn_3 823_splitncnn_2 826_splitncnn_2 827
+Convolution      Conv_125                 1 1 827 829 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_31             1 2 829 829_splitncnn_0 829_splitncnn_1
+Concat           Concat_127               4 1 821_splitncnn_2 823_splitncnn_1 826_splitncnn_1 829_splitncnn_1 830
+Convolution      Conv_128                 1 1 830 832 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_130               5 1 821_splitncnn_1 823_splitncnn_0 826_splitncnn_0 829_splitncnn_0 832 833
+Convolution      Conv_131                 1 1 833 834 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_134                  2 1 834 821_splitncnn_0 837 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_32             1 6 837 837_splitncnn_0 837_splitncnn_1 837_splitncnn_2 837_splitncnn_3 837_splitncnn_4 837_splitncnn_5
+Convolution      Conv_135                 1 1 837_splitncnn_5 839 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_33             1 4 839 839_splitncnn_0 839_splitncnn_1 839_splitncnn_2 839_splitncnn_3
+Concat           Concat_137               2 1 837_splitncnn_4 839_splitncnn_3 840
+Convolution      Conv_138                 1 1 840 842 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_34             1 3 842 842_splitncnn_0 842_splitncnn_1 842_splitncnn_2
+Concat           Concat_140               3 1 837_splitncnn_3 839_splitncnn_2 842_splitncnn_2 843
+Convolution      Conv_141                 1 1 843 845 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_35             1 2 845 845_splitncnn_0 845_splitncnn_1
+Concat           Concat_143               4 1 837_splitncnn_2 839_splitncnn_1 842_splitncnn_1 845_splitncnn_1 846
+Convolution      Conv_144                 1 1 846 848 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_146               5 1 837_splitncnn_1 839_splitncnn_0 842_splitncnn_0 845_splitncnn_0 848 849
+Convolution      Conv_147                 1 1 849 850 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_150                  2 1 850 837_splitncnn_0 853 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_153                  2 1 853 805_splitncnn_0 856 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_36             1 7 856 856_splitncnn_0 856_splitncnn_1 856_splitncnn_2 856_splitncnn_3 856_splitncnn_4 856_splitncnn_5 856_splitncnn_6
+Convolution      Conv_154                 1 1 856_splitncnn_6 858 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_37             1 4 858 858_splitncnn_0 858_splitncnn_1 858_splitncnn_2 858_splitncnn_3
+Concat           Concat_156               2 1 856_splitncnn_5 858_splitncnn_3 859
+Convolution      Conv_157                 1 1 859 861 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_38             1 3 861 861_splitncnn_0 861_splitncnn_1 861_splitncnn_2
+Concat           Concat_159               3 1 856_splitncnn_4 858_splitncnn_2 861_splitncnn_2 862
+Convolution      Conv_160                 1 1 862 864 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_39             1 2 864 864_splitncnn_0 864_splitncnn_1
+Concat           Concat_162               4 1 856_splitncnn_3 858_splitncnn_1 861_splitncnn_1 864_splitncnn_1 865
+Convolution      Conv_163                 1 1 865 867 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_165               5 1 856_splitncnn_2 858_splitncnn_0 861_splitncnn_0 864_splitncnn_0 867 868
+Convolution      Conv_166                 1 1 868 869 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_169                  2 1 869 856_splitncnn_1 872 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_40             1 6 872 872_splitncnn_0 872_splitncnn_1 872_splitncnn_2 872_splitncnn_3 872_splitncnn_4 872_splitncnn_5
+Convolution      Conv_170                 1 1 872_splitncnn_5 874 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_41             1 4 874 874_splitncnn_0 874_splitncnn_1 874_splitncnn_2 874_splitncnn_3
+Concat           Concat_172               2 1 872_splitncnn_4 874_splitncnn_3 875
+Convolution      Conv_173                 1 1 875 877 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_42             1 3 877 877_splitncnn_0 877_splitncnn_1 877_splitncnn_2
+Concat           Concat_175               3 1 872_splitncnn_3 874_splitncnn_2 877_splitncnn_2 878
+Convolution      Conv_176                 1 1 878 880 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_43             1 2 880 880_splitncnn_0 880_splitncnn_1
+Concat           Concat_178               4 1 872_splitncnn_2 874_splitncnn_1 877_splitncnn_1 880_splitncnn_1 881
+Convolution      Conv_179                 1 1 881 883 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_181               5 1 872_splitncnn_1 874_splitncnn_0 877_splitncnn_0 880_splitncnn_0 883 884
+Convolution      Conv_182                 1 1 884 885 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_185                  2 1 885 872_splitncnn_0 888 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_44             1 6 888 888_splitncnn_0 888_splitncnn_1 888_splitncnn_2 888_splitncnn_3 888_splitncnn_4 888_splitncnn_5
+Convolution      Conv_186                 1 1 888_splitncnn_5 890 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_45             1 4 890 890_splitncnn_0 890_splitncnn_1 890_splitncnn_2 890_splitncnn_3
+Concat           Concat_188               2 1 888_splitncnn_4 890_splitncnn_3 891
+Convolution      Conv_189                 1 1 891 893 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_46             1 3 893 893_splitncnn_0 893_splitncnn_1 893_splitncnn_2
+Concat           Concat_191               3 1 888_splitncnn_3 890_splitncnn_2 893_splitncnn_2 894
+Convolution      Conv_192                 1 1 894 896 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_47             1 2 896 896_splitncnn_0 896_splitncnn_1
+Concat           Concat_194               4 1 888_splitncnn_2 890_splitncnn_1 893_splitncnn_1 896_splitncnn_1 897
+Convolution      Conv_195                 1 1 897 899 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_197               5 1 888_splitncnn_1 890_splitncnn_0 893_splitncnn_0 896_splitncnn_0 899 900
+Convolution      Conv_198                 1 1 900 901 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_201                  2 1 901 888_splitncnn_0 904 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_204                  2 1 904 856_splitncnn_0 907 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_48             1 7 907 907_splitncnn_0 907_splitncnn_1 907_splitncnn_2 907_splitncnn_3 907_splitncnn_4 907_splitncnn_5 907_splitncnn_6
+Convolution      Conv_205                 1 1 907_splitncnn_6 909 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_49             1 4 909 909_splitncnn_0 909_splitncnn_1 909_splitncnn_2 909_splitncnn_3
+Concat           Concat_207               2 1 907_splitncnn_5 909_splitncnn_3 910
+Convolution      Conv_208                 1 1 910 912 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_50             1 3 912 912_splitncnn_0 912_splitncnn_1 912_splitncnn_2
+Concat           Concat_210               3 1 907_splitncnn_4 909_splitncnn_2 912_splitncnn_2 913
+Convolution      Conv_211                 1 1 913 915 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_51             1 2 915 915_splitncnn_0 915_splitncnn_1
+Concat           Concat_213               4 1 907_splitncnn_3 909_splitncnn_1 912_splitncnn_1 915_splitncnn_1 916
+Convolution      Conv_214                 1 1 916 918 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_216               5 1 907_splitncnn_2 909_splitncnn_0 912_splitncnn_0 915_splitncnn_0 918 919
+Convolution      Conv_217                 1 1 919 920 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_220                  2 1 920 907_splitncnn_1 923 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_52             1 6 923 923_splitncnn_0 923_splitncnn_1 923_splitncnn_2 923_splitncnn_3 923_splitncnn_4 923_splitncnn_5
+Convolution      Conv_221                 1 1 923_splitncnn_5 925 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_53             1 4 925 925_splitncnn_0 925_splitncnn_1 925_splitncnn_2 925_splitncnn_3
+Concat           Concat_223               2 1 923_splitncnn_4 925_splitncnn_3 926
+Convolution      Conv_224                 1 1 926 928 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_54             1 3 928 928_splitncnn_0 928_splitncnn_1 928_splitncnn_2
+Concat           Concat_226               3 1 923_splitncnn_3 925_splitncnn_2 928_splitncnn_2 929
+Convolution      Conv_227                 1 1 929 931 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_55             1 2 931 931_splitncnn_0 931_splitncnn_1
+Concat           Concat_229               4 1 923_splitncnn_2 925_splitncnn_1 928_splitncnn_1 931_splitncnn_1 932
+Convolution      Conv_230                 1 1 932 934 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_232               5 1 923_splitncnn_1 925_splitncnn_0 928_splitncnn_0 931_splitncnn_0 934 935
+Convolution      Conv_233                 1 1 935 936 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_236                  2 1 936 923_splitncnn_0 939 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_56             1 6 939 939_splitncnn_0 939_splitncnn_1 939_splitncnn_2 939_splitncnn_3 939_splitncnn_4 939_splitncnn_5
+Convolution      Conv_237                 1 1 939_splitncnn_5 941 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_57             1 4 941 941_splitncnn_0 941_splitncnn_1 941_splitncnn_2 941_splitncnn_3
+Concat           Concat_239               2 1 939_splitncnn_4 941_splitncnn_3 942
+Convolution      Conv_240                 1 1 942 944 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_58             1 3 944 944_splitncnn_0 944_splitncnn_1 944_splitncnn_2
+Concat           Concat_242               3 1 939_splitncnn_3 941_splitncnn_2 944_splitncnn_2 945
+Convolution      Conv_243                 1 1 945 947 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_59             1 2 947 947_splitncnn_0 947_splitncnn_1
+Concat           Concat_245               4 1 939_splitncnn_2 941_splitncnn_1 944_splitncnn_1 947_splitncnn_1 948
+Convolution      Conv_246                 1 1 948 950 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_248               5 1 939_splitncnn_1 941_splitncnn_0 944_splitncnn_0 947_splitncnn_0 950 951
+Convolution      Conv_249                 1 1 951 952 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_252                  2 1 952 939_splitncnn_0 955 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_255                  2 1 955 907_splitncnn_0 958 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_60             1 7 958 958_splitncnn_0 958_splitncnn_1 958_splitncnn_2 958_splitncnn_3 958_splitncnn_4 958_splitncnn_5 958_splitncnn_6
+Convolution      Conv_256                 1 1 958_splitncnn_6 960 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_61             1 4 960 960_splitncnn_0 960_splitncnn_1 960_splitncnn_2 960_splitncnn_3
+Concat           Concat_258               2 1 958_splitncnn_5 960_splitncnn_3 961
+Convolution      Conv_259                 1 1 961 963 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_62             1 3 963 963_splitncnn_0 963_splitncnn_1 963_splitncnn_2
+Concat           Concat_261               3 1 958_splitncnn_4 960_splitncnn_2 963_splitncnn_2 964
+Convolution      Conv_262                 1 1 964 966 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_63             1 2 966 966_splitncnn_0 966_splitncnn_1
+Concat           Concat_264               4 1 958_splitncnn_3 960_splitncnn_1 963_splitncnn_1 966_splitncnn_1 967
+Convolution      Conv_265                 1 1 967 969 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_267               5 1 958_splitncnn_2 960_splitncnn_0 963_splitncnn_0 966_splitncnn_0 969 970
+Convolution      Conv_268                 1 1 970 971 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_271                  2 1 971 958_splitncnn_1 974 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_64             1 6 974 974_splitncnn_0 974_splitncnn_1 974_splitncnn_2 974_splitncnn_3 974_splitncnn_4 974_splitncnn_5
+Convolution      Conv_272                 1 1 974_splitncnn_5 976 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_65             1 4 976 976_splitncnn_0 976_splitncnn_1 976_splitncnn_2 976_splitncnn_3
+Concat           Concat_274               2 1 974_splitncnn_4 976_splitncnn_3 977
+Convolution      Conv_275                 1 1 977 979 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_66             1 3 979 979_splitncnn_0 979_splitncnn_1 979_splitncnn_2
+Concat           Concat_277               3 1 974_splitncnn_3 976_splitncnn_2 979_splitncnn_2 980
+Convolution      Conv_278                 1 1 980 982 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_67             1 2 982 982_splitncnn_0 982_splitncnn_1
+Concat           Concat_280               4 1 974_splitncnn_2 976_splitncnn_1 979_splitncnn_1 982_splitncnn_1 983
+Convolution      Conv_281                 1 1 983 985 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_283               5 1 974_splitncnn_1 976_splitncnn_0 979_splitncnn_0 982_splitncnn_0 985 986
+Convolution      Conv_284                 1 1 986 987 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_287                  2 1 987 974_splitncnn_0 990 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_68             1 6 990 990_splitncnn_0 990_splitncnn_1 990_splitncnn_2 990_splitncnn_3 990_splitncnn_4 990_splitncnn_5
+Convolution      Conv_288                 1 1 990_splitncnn_5 992 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_69             1 4 992 992_splitncnn_0 992_splitncnn_1 992_splitncnn_2 992_splitncnn_3
+Concat           Concat_290               2 1 990_splitncnn_4 992_splitncnn_3 993
+Convolution      Conv_291                 1 1 993 995 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_70             1 3 995 995_splitncnn_0 995_splitncnn_1 995_splitncnn_2
+Concat           Concat_293               3 1 990_splitncnn_3 992_splitncnn_2 995_splitncnn_2 996
+Convolution      Conv_294                 1 1 996 998 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_71             1 2 998 998_splitncnn_0 998_splitncnn_1
+Concat           Concat_296               4 1 990_splitncnn_2 992_splitncnn_1 995_splitncnn_1 998_splitncnn_1 999
+Convolution      Conv_297                 1 1 999 1001 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_299               5 1 990_splitncnn_1 992_splitncnn_0 995_splitncnn_0 998_splitncnn_0 1001 1002
+Convolution      Conv_300                 1 1 1002 1003 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_303                  2 1 1003 990_splitncnn_0 1006 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_306                  2 1 1006 958_splitncnn_0 1009 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_72             1 7 1009 1009_splitncnn_0 1009_splitncnn_1 1009_splitncnn_2 1009_splitncnn_3 1009_splitncnn_4 1009_splitncnn_5 1009_splitncnn_6
+Convolution      Conv_307                 1 1 1009_splitncnn_6 1011 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_73             1 4 1011 1011_splitncnn_0 1011_splitncnn_1 1011_splitncnn_2 1011_splitncnn_3
+Concat           Concat_309               2 1 1009_splitncnn_5 1011_splitncnn_3 1012
+Convolution      Conv_310                 1 1 1012 1014 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_74             1 3 1014 1014_splitncnn_0 1014_splitncnn_1 1014_splitncnn_2
+Concat           Concat_312               3 1 1009_splitncnn_4 1011_splitncnn_2 1014_splitncnn_2 1015
+Convolution      Conv_313                 1 1 1015 1017 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_75             1 2 1017 1017_splitncnn_0 1017_splitncnn_1
+Concat           Concat_315               4 1 1009_splitncnn_3 1011_splitncnn_1 1014_splitncnn_1 1017_splitncnn_1 1018
+Convolution      Conv_316                 1 1 1018 1020 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_318               5 1 1009_splitncnn_2 1011_splitncnn_0 1014_splitncnn_0 1017_splitncnn_0 1020 1021
+Convolution      Conv_319                 1 1 1021 1022 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_322                  2 1 1022 1009_splitncnn_1 1025 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_76             1 6 1025 1025_splitncnn_0 1025_splitncnn_1 1025_splitncnn_2 1025_splitncnn_3 1025_splitncnn_4 1025_splitncnn_5
+Convolution      Conv_323                 1 1 1025_splitncnn_5 1027 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_77             1 4 1027 1027_splitncnn_0 1027_splitncnn_1 1027_splitncnn_2 1027_splitncnn_3
+Concat           Concat_325               2 1 1025_splitncnn_4 1027_splitncnn_3 1028
+Convolution      Conv_326                 1 1 1028 1030 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_78             1 3 1030 1030_splitncnn_0 1030_splitncnn_1 1030_splitncnn_2
+Concat           Concat_328               3 1 1025_splitncnn_3 1027_splitncnn_2 1030_splitncnn_2 1031
+Convolution      Conv_329                 1 1 1031 1033 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_79             1 2 1033 1033_splitncnn_0 1033_splitncnn_1
+Concat           Concat_331               4 1 1025_splitncnn_2 1027_splitncnn_1 1030_splitncnn_1 1033_splitncnn_1 1034
+Convolution      Conv_332                 1 1 1034 1036 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_334               5 1 1025_splitncnn_1 1027_splitncnn_0 1030_splitncnn_0 1033_splitncnn_0 1036 1037
+Convolution      Conv_335                 1 1 1037 1038 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_338                  2 1 1038 1025_splitncnn_0 1041 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_80             1 6 1041 1041_splitncnn_0 1041_splitncnn_1 1041_splitncnn_2 1041_splitncnn_3 1041_splitncnn_4 1041_splitncnn_5
+Convolution      Conv_339                 1 1 1041_splitncnn_5 1043 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_81             1 4 1043 1043_splitncnn_0 1043_splitncnn_1 1043_splitncnn_2 1043_splitncnn_3
+Concat           Concat_341               2 1 1041_splitncnn_4 1043_splitncnn_3 1044
+Convolution      Conv_342                 1 1 1044 1046 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_82             1 3 1046 1046_splitncnn_0 1046_splitncnn_1 1046_splitncnn_2
+Concat           Concat_344               3 1 1041_splitncnn_3 1043_splitncnn_2 1046_splitncnn_2 1047
+Convolution      Conv_345                 1 1 1047 1049 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_83             1 2 1049 1049_splitncnn_0 1049_splitncnn_1
+Concat           Concat_347               4 1 1041_splitncnn_2 1043_splitncnn_1 1046_splitncnn_1 1049_splitncnn_1 1050
+Convolution      Conv_348                 1 1 1050 1052 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_350               5 1 1041_splitncnn_1 1043_splitncnn_0 1046_splitncnn_0 1049_splitncnn_0 1052 1053
+Convolution      Conv_351                 1 1 1053 1054 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_354                  2 1 1054 1041_splitncnn_0 1057 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_357                  2 1 1057 1009_splitncnn_0 1060 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_84             1 7 1060 1060_splitncnn_0 1060_splitncnn_1 1060_splitncnn_2 1060_splitncnn_3 1060_splitncnn_4 1060_splitncnn_5 1060_splitncnn_6
+Convolution      Conv_358                 1 1 1060_splitncnn_6 1062 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_85             1 4 1062 1062_splitncnn_0 1062_splitncnn_1 1062_splitncnn_2 1062_splitncnn_3
+Concat           Concat_360               2 1 1060_splitncnn_5 1062_splitncnn_3 1063
+Convolution      Conv_361                 1 1 1063 1065 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_86             1 3 1065 1065_splitncnn_0 1065_splitncnn_1 1065_splitncnn_2
+Concat           Concat_363               3 1 1060_splitncnn_4 1062_splitncnn_2 1065_splitncnn_2 1066
+Convolution      Conv_364                 1 1 1066 1068 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_87             1 2 1068 1068_splitncnn_0 1068_splitncnn_1
+Concat           Concat_366               4 1 1060_splitncnn_3 1062_splitncnn_1 1065_splitncnn_1 1068_splitncnn_1 1069
+Convolution      Conv_367                 1 1 1069 1071 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_369               5 1 1060_splitncnn_2 1062_splitncnn_0 1065_splitncnn_0 1068_splitncnn_0 1071 1072
+Convolution      Conv_370                 1 1 1072 1073 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_373                  2 1 1073 1060_splitncnn_1 1076 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_88             1 6 1076 1076_splitncnn_0 1076_splitncnn_1 1076_splitncnn_2 1076_splitncnn_3 1076_splitncnn_4 1076_splitncnn_5
+Convolution      Conv_374                 1 1 1076_splitncnn_5 1078 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_89             1 4 1078 1078_splitncnn_0 1078_splitncnn_1 1078_splitncnn_2 1078_splitncnn_3
+Concat           Concat_376               2 1 1076_splitncnn_4 1078_splitncnn_3 1079
+Convolution      Conv_377                 1 1 1079 1081 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_90             1 3 1081 1081_splitncnn_0 1081_splitncnn_1 1081_splitncnn_2
+Concat           Concat_379               3 1 1076_splitncnn_3 1078_splitncnn_2 1081_splitncnn_2 1082
+Convolution      Conv_380                 1 1 1082 1084 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_91             1 2 1084 1084_splitncnn_0 1084_splitncnn_1
+Concat           Concat_382               4 1 1076_splitncnn_2 1078_splitncnn_1 1081_splitncnn_1 1084_splitncnn_1 1085
+Convolution      Conv_383                 1 1 1085 1087 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_385               5 1 1076_splitncnn_1 1078_splitncnn_0 1081_splitncnn_0 1084_splitncnn_0 1087 1088
+Convolution      Conv_386                 1 1 1088 1089 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_389                  2 1 1089 1076_splitncnn_0 1092 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_92             1 6 1092 1092_splitncnn_0 1092_splitncnn_1 1092_splitncnn_2 1092_splitncnn_3 1092_splitncnn_4 1092_splitncnn_5
+Convolution      Conv_390                 1 1 1092_splitncnn_5 1094 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_93             1 4 1094 1094_splitncnn_0 1094_splitncnn_1 1094_splitncnn_2 1094_splitncnn_3
+Concat           Concat_392               2 1 1092_splitncnn_4 1094_splitncnn_3 1095
+Convolution      Conv_393                 1 1 1095 1097 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_94             1 3 1097 1097_splitncnn_0 1097_splitncnn_1 1097_splitncnn_2
+Concat           Concat_395               3 1 1092_splitncnn_3 1094_splitncnn_2 1097_splitncnn_2 1098
+Convolution      Conv_396                 1 1 1098 1100 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_95             1 2 1100 1100_splitncnn_0 1100_splitncnn_1
+Concat           Concat_398               4 1 1092_splitncnn_2 1094_splitncnn_1 1097_splitncnn_1 1100_splitncnn_1 1101
+Convolution      Conv_399                 1 1 1101 1103 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_401               5 1 1092_splitncnn_1 1094_splitncnn_0 1097_splitncnn_0 1100_splitncnn_0 1103 1104
+Convolution      Conv_402                 1 1 1104 1105 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_405                  2 1 1105 1092_splitncnn_0 1108 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_408                  2 1 1108 1060_splitncnn_0 1111 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_96             1 7 1111 1111_splitncnn_0 1111_splitncnn_1 1111_splitncnn_2 1111_splitncnn_3 1111_splitncnn_4 1111_splitncnn_5 1111_splitncnn_6
+Convolution      Conv_409                 1 1 1111_splitncnn_6 1113 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_97             1 4 1113 1113_splitncnn_0 1113_splitncnn_1 1113_splitncnn_2 1113_splitncnn_3
+Concat           Concat_411               2 1 1111_splitncnn_5 1113_splitncnn_3 1114
+Convolution      Conv_412                 1 1 1114 1116 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_98             1 3 1116 1116_splitncnn_0 1116_splitncnn_1 1116_splitncnn_2
+Concat           Concat_414               3 1 1111_splitncnn_4 1113_splitncnn_2 1116_splitncnn_2 1117
+Convolution      Conv_415                 1 1 1117 1119 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_99             1 2 1119 1119_splitncnn_0 1119_splitncnn_1
+Concat           Concat_417               4 1 1111_splitncnn_3 1113_splitncnn_1 1116_splitncnn_1 1119_splitncnn_1 1120
+Convolution      Conv_418                 1 1 1120 1122 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_420               5 1 1111_splitncnn_2 1113_splitncnn_0 1116_splitncnn_0 1119_splitncnn_0 1122 1123
+Convolution      Conv_421                 1 1 1123 1124 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_424                  2 1 1124 1111_splitncnn_1 1127 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_100            1 6 1127 1127_splitncnn_0 1127_splitncnn_1 1127_splitncnn_2 1127_splitncnn_3 1127_splitncnn_4 1127_splitncnn_5
+Convolution      Conv_425                 1 1 1127_splitncnn_5 1129 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_101            1 4 1129 1129_splitncnn_0 1129_splitncnn_1 1129_splitncnn_2 1129_splitncnn_3
+Concat           Concat_427               2 1 1127_splitncnn_4 1129_splitncnn_3 1130
+Convolution      Conv_428                 1 1 1130 1132 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_102            1 3 1132 1132_splitncnn_0 1132_splitncnn_1 1132_splitncnn_2
+Concat           Concat_430               3 1 1127_splitncnn_3 1129_splitncnn_2 1132_splitncnn_2 1133
+Convolution      Conv_431                 1 1 1133 1135 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_103            1 2 1135 1135_splitncnn_0 1135_splitncnn_1
+Concat           Concat_433               4 1 1127_splitncnn_2 1129_splitncnn_1 1132_splitncnn_1 1135_splitncnn_1 1136
+Convolution      Conv_434                 1 1 1136 1138 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_436               5 1 1127_splitncnn_1 1129_splitncnn_0 1132_splitncnn_0 1135_splitncnn_0 1138 1139
+Convolution      Conv_437                 1 1 1139 1140 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_440                  2 1 1140 1127_splitncnn_0 1143 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_104            1 6 1143 1143_splitncnn_0 1143_splitncnn_1 1143_splitncnn_2 1143_splitncnn_3 1143_splitncnn_4 1143_splitncnn_5
+Convolution      Conv_441                 1 1 1143_splitncnn_5 1145 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_105            1 4 1145 1145_splitncnn_0 1145_splitncnn_1 1145_splitncnn_2 1145_splitncnn_3
+Concat           Concat_443               2 1 1143_splitncnn_4 1145_splitncnn_3 1146
+Convolution      Conv_444                 1 1 1146 1148 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_106            1 3 1148 1148_splitncnn_0 1148_splitncnn_1 1148_splitncnn_2
+Concat           Concat_446               3 1 1143_splitncnn_3 1145_splitncnn_2 1148_splitncnn_2 1149
+Convolution      Conv_447                 1 1 1149 1151 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_107            1 2 1151 1151_splitncnn_0 1151_splitncnn_1
+Concat           Concat_449               4 1 1143_splitncnn_2 1145_splitncnn_1 1148_splitncnn_1 1151_splitncnn_1 1152
+Convolution      Conv_450                 1 1 1152 1154 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_452               5 1 1143_splitncnn_1 1145_splitncnn_0 1148_splitncnn_0 1151_splitncnn_0 1154 1155
+Convolution      Conv_453                 1 1 1155 1156 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_456                  2 1 1156 1143_splitncnn_0 1159 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_459                  2 1 1159 1111_splitncnn_0 1162 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_108            1 7 1162 1162_splitncnn_0 1162_splitncnn_1 1162_splitncnn_2 1162_splitncnn_3 1162_splitncnn_4 1162_splitncnn_5 1162_splitncnn_6
+Convolution      Conv_460                 1 1 1162_splitncnn_6 1164 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_109            1 4 1164 1164_splitncnn_0 1164_splitncnn_1 1164_splitncnn_2 1164_splitncnn_3
+Concat           Concat_462               2 1 1162_splitncnn_5 1164_splitncnn_3 1165
+Convolution      Conv_463                 1 1 1165 1167 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_110            1 3 1167 1167_splitncnn_0 1167_splitncnn_1 1167_splitncnn_2
+Concat           Concat_465               3 1 1162_splitncnn_4 1164_splitncnn_2 1167_splitncnn_2 1168
+Convolution      Conv_466                 1 1 1168 1170 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_111            1 2 1170 1170_splitncnn_0 1170_splitncnn_1
+Concat           Concat_468               4 1 1162_splitncnn_3 1164_splitncnn_1 1167_splitncnn_1 1170_splitncnn_1 1171
+Convolution      Conv_469                 1 1 1171 1173 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_471               5 1 1162_splitncnn_2 1164_splitncnn_0 1167_splitncnn_0 1170_splitncnn_0 1173 1174
+Convolution      Conv_472                 1 1 1174 1175 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_475                  2 1 1175 1162_splitncnn_1 1178 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_112            1 6 1178 1178_splitncnn_0 1178_splitncnn_1 1178_splitncnn_2 1178_splitncnn_3 1178_splitncnn_4 1178_splitncnn_5
+Convolution      Conv_476                 1 1 1178_splitncnn_5 1180 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_113            1 4 1180 1180_splitncnn_0 1180_splitncnn_1 1180_splitncnn_2 1180_splitncnn_3
+Concat           Concat_478               2 1 1178_splitncnn_4 1180_splitncnn_3 1181
+Convolution      Conv_479                 1 1 1181 1183 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_114            1 3 1183 1183_splitncnn_0 1183_splitncnn_1 1183_splitncnn_2
+Concat           Concat_481               3 1 1178_splitncnn_3 1180_splitncnn_2 1183_splitncnn_2 1184
+Convolution      Conv_482                 1 1 1184 1186 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_115            1 2 1186 1186_splitncnn_0 1186_splitncnn_1
+Concat           Concat_484               4 1 1178_splitncnn_2 1180_splitncnn_1 1183_splitncnn_1 1186_splitncnn_1 1187
+Convolution      Conv_485                 1 1 1187 1189 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_487               5 1 1178_splitncnn_1 1180_splitncnn_0 1183_splitncnn_0 1186_splitncnn_0 1189 1190
+Convolution      Conv_488                 1 1 1190 1191 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_491                  2 1 1191 1178_splitncnn_0 1194 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_116            1 6 1194 1194_splitncnn_0 1194_splitncnn_1 1194_splitncnn_2 1194_splitncnn_3 1194_splitncnn_4 1194_splitncnn_5
+Convolution      Conv_492                 1 1 1194_splitncnn_5 1196 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_117            1 4 1196 1196_splitncnn_0 1196_splitncnn_1 1196_splitncnn_2 1196_splitncnn_3
+Concat           Concat_494               2 1 1194_splitncnn_4 1196_splitncnn_3 1197
+Convolution      Conv_495                 1 1 1197 1199 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_118            1 3 1199 1199_splitncnn_0 1199_splitncnn_1 1199_splitncnn_2
+Concat           Concat_497               3 1 1194_splitncnn_3 1196_splitncnn_2 1199_splitncnn_2 1200
+Convolution      Conv_498                 1 1 1200 1202 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_119            1 2 1202 1202_splitncnn_0 1202_splitncnn_1
+Concat           Concat_500               4 1 1194_splitncnn_2 1196_splitncnn_1 1199_splitncnn_1 1202_splitncnn_1 1203
+Convolution      Conv_501                 1 1 1203 1205 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_503               5 1 1194_splitncnn_1 1196_splitncnn_0 1199_splitncnn_0 1202_splitncnn_0 1205 1206
+Convolution      Conv_504                 1 1 1206 1207 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_507                  2 1 1207 1194_splitncnn_0 1210 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_510                  2 1 1210 1162_splitncnn_0 1213 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_120            1 7 1213 1213_splitncnn_0 1213_splitncnn_1 1213_splitncnn_2 1213_splitncnn_3 1213_splitncnn_4 1213_splitncnn_5 1213_splitncnn_6
+Convolution      Conv_511                 1 1 1213_splitncnn_6 1215 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_121            1 4 1215 1215_splitncnn_0 1215_splitncnn_1 1215_splitncnn_2 1215_splitncnn_3
+Concat           Concat_513               2 1 1213_splitncnn_5 1215_splitncnn_3 1216
+Convolution      Conv_514                 1 1 1216 1218 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_122            1 3 1218 1218_splitncnn_0 1218_splitncnn_1 1218_splitncnn_2
+Concat           Concat_516               3 1 1213_splitncnn_4 1215_splitncnn_2 1218_splitncnn_2 1219
+Convolution      Conv_517                 1 1 1219 1221 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_123            1 2 1221 1221_splitncnn_0 1221_splitncnn_1
+Concat           Concat_519               4 1 1213_splitncnn_3 1215_splitncnn_1 1218_splitncnn_1 1221_splitncnn_1 1222
+Convolution      Conv_520                 1 1 1222 1224 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_522               5 1 1213_splitncnn_2 1215_splitncnn_0 1218_splitncnn_0 1221_splitncnn_0 1224 1225
+Convolution      Conv_523                 1 1 1225 1226 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_526                  2 1 1226 1213_splitncnn_1 1229 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_124            1 6 1229 1229_splitncnn_0 1229_splitncnn_1 1229_splitncnn_2 1229_splitncnn_3 1229_splitncnn_4 1229_splitncnn_5
+Convolution      Conv_527                 1 1 1229_splitncnn_5 1231 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_125            1 4 1231 1231_splitncnn_0 1231_splitncnn_1 1231_splitncnn_2 1231_splitncnn_3
+Concat           Concat_529               2 1 1229_splitncnn_4 1231_splitncnn_3 1232
+Convolution      Conv_530                 1 1 1232 1234 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_126            1 3 1234 1234_splitncnn_0 1234_splitncnn_1 1234_splitncnn_2
+Concat           Concat_532               3 1 1229_splitncnn_3 1231_splitncnn_2 1234_splitncnn_2 1235
+Convolution      Conv_533                 1 1 1235 1237 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_127            1 2 1237 1237_splitncnn_0 1237_splitncnn_1
+Concat           Concat_535               4 1 1229_splitncnn_2 1231_splitncnn_1 1234_splitncnn_1 1237_splitncnn_1 1238
+Convolution      Conv_536                 1 1 1238 1240 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_538               5 1 1229_splitncnn_1 1231_splitncnn_0 1234_splitncnn_0 1237_splitncnn_0 1240 1241
+Convolution      Conv_539                 1 1 1241 1242 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_542                  2 1 1242 1229_splitncnn_0 1245 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_128            1 6 1245 1245_splitncnn_0 1245_splitncnn_1 1245_splitncnn_2 1245_splitncnn_3 1245_splitncnn_4 1245_splitncnn_5
+Convolution      Conv_543                 1 1 1245_splitncnn_5 1247 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_129            1 4 1247 1247_splitncnn_0 1247_splitncnn_1 1247_splitncnn_2 1247_splitncnn_3
+Concat           Concat_545               2 1 1245_splitncnn_4 1247_splitncnn_3 1248
+Convolution      Conv_546                 1 1 1248 1250 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_130            1 3 1250 1250_splitncnn_0 1250_splitncnn_1 1250_splitncnn_2
+Concat           Concat_548               3 1 1245_splitncnn_3 1247_splitncnn_2 1250_splitncnn_2 1251
+Convolution      Conv_549                 1 1 1251 1253 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_131            1 2 1253 1253_splitncnn_0 1253_splitncnn_1
+Concat           Concat_551               4 1 1245_splitncnn_2 1247_splitncnn_1 1250_splitncnn_1 1253_splitncnn_1 1254
+Convolution      Conv_552                 1 1 1254 1256 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_554               5 1 1245_splitncnn_1 1247_splitncnn_0 1250_splitncnn_0 1253_splitncnn_0 1256 1257
+Convolution      Conv_555                 1 1 1257 1258 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_558                  2 1 1258 1245_splitncnn_0 1261 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_561                  2 1 1261 1213_splitncnn_0 1264 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_132            1 7 1264 1264_splitncnn_0 1264_splitncnn_1 1264_splitncnn_2 1264_splitncnn_3 1264_splitncnn_4 1264_splitncnn_5 1264_splitncnn_6
+Convolution      Conv_562                 1 1 1264_splitncnn_6 1266 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_133            1 4 1266 1266_splitncnn_0 1266_splitncnn_1 1266_splitncnn_2 1266_splitncnn_3
+Concat           Concat_564               2 1 1264_splitncnn_5 1266_splitncnn_3 1267
+Convolution      Conv_565                 1 1 1267 1269 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_134            1 3 1269 1269_splitncnn_0 1269_splitncnn_1 1269_splitncnn_2
+Concat           Concat_567               3 1 1264_splitncnn_4 1266_splitncnn_2 1269_splitncnn_2 1270
+Convolution      Conv_568                 1 1 1270 1272 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_135            1 2 1272 1272_splitncnn_0 1272_splitncnn_1
+Concat           Concat_570               4 1 1264_splitncnn_3 1266_splitncnn_1 1269_splitncnn_1 1272_splitncnn_1 1273
+Convolution      Conv_571                 1 1 1273 1275 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_573               5 1 1264_splitncnn_2 1266_splitncnn_0 1269_splitncnn_0 1272_splitncnn_0 1275 1276
+Convolution      Conv_574                 1 1 1276 1277 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_577                  2 1 1277 1264_splitncnn_1 1280 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_136            1 6 1280 1280_splitncnn_0 1280_splitncnn_1 1280_splitncnn_2 1280_splitncnn_3 1280_splitncnn_4 1280_splitncnn_5
+Convolution      Conv_578                 1 1 1280_splitncnn_5 1282 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_137            1 4 1282 1282_splitncnn_0 1282_splitncnn_1 1282_splitncnn_2 1282_splitncnn_3
+Concat           Concat_580               2 1 1280_splitncnn_4 1282_splitncnn_3 1283
+Convolution      Conv_581                 1 1 1283 1285 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_138            1 3 1285 1285_splitncnn_0 1285_splitncnn_1 1285_splitncnn_2
+Concat           Concat_583               3 1 1280_splitncnn_3 1282_splitncnn_2 1285_splitncnn_2 1286
+Convolution      Conv_584                 1 1 1286 1288 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_139            1 2 1288 1288_splitncnn_0 1288_splitncnn_1
+Concat           Concat_586               4 1 1280_splitncnn_2 1282_splitncnn_1 1285_splitncnn_1 1288_splitncnn_1 1289
+Convolution      Conv_587                 1 1 1289 1291 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_589               5 1 1280_splitncnn_1 1282_splitncnn_0 1285_splitncnn_0 1288_splitncnn_0 1291 1292
+Convolution      Conv_590                 1 1 1292 1293 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_593                  2 1 1293 1280_splitncnn_0 1296 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_140            1 6 1296 1296_splitncnn_0 1296_splitncnn_1 1296_splitncnn_2 1296_splitncnn_3 1296_splitncnn_4 1296_splitncnn_5
+Convolution      Conv_594                 1 1 1296_splitncnn_5 1298 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_141            1 4 1298 1298_splitncnn_0 1298_splitncnn_1 1298_splitncnn_2 1298_splitncnn_3
+Concat           Concat_596               2 1 1296_splitncnn_4 1298_splitncnn_3 1299
+Convolution      Conv_597                 1 1 1299 1301 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_142            1 3 1301 1301_splitncnn_0 1301_splitncnn_1 1301_splitncnn_2
+Concat           Concat_599               3 1 1296_splitncnn_3 1298_splitncnn_2 1301_splitncnn_2 1302
+Convolution      Conv_600                 1 1 1302 1304 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_143            1 2 1304 1304_splitncnn_0 1304_splitncnn_1
+Concat           Concat_602               4 1 1296_splitncnn_2 1298_splitncnn_1 1301_splitncnn_1 1304_splitncnn_1 1305
+Convolution      Conv_603                 1 1 1305 1307 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_605               5 1 1296_splitncnn_1 1298_splitncnn_0 1301_splitncnn_0 1304_splitncnn_0 1307 1308
+Convolution      Conv_606                 1 1 1308 1309 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_609                  2 1 1309 1296_splitncnn_0 1312 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_612                  2 1 1312 1264_splitncnn_0 1315 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_144            1 7 1315 1315_splitncnn_0 1315_splitncnn_1 1315_splitncnn_2 1315_splitncnn_3 1315_splitncnn_4 1315_splitncnn_5 1315_splitncnn_6
+Convolution      Conv_613                 1 1 1315_splitncnn_6 1317 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_145            1 4 1317 1317_splitncnn_0 1317_splitncnn_1 1317_splitncnn_2 1317_splitncnn_3
+Concat           Concat_615               2 1 1315_splitncnn_5 1317_splitncnn_3 1318
+Convolution      Conv_616                 1 1 1318 1320 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_146            1 3 1320 1320_splitncnn_0 1320_splitncnn_1 1320_splitncnn_2
+Concat           Concat_618               3 1 1315_splitncnn_4 1317_splitncnn_2 1320_splitncnn_2 1321
+Convolution      Conv_619                 1 1 1321 1323 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_147            1 2 1323 1323_splitncnn_0 1323_splitncnn_1
+Concat           Concat_621               4 1 1315_splitncnn_3 1317_splitncnn_1 1320_splitncnn_1 1323_splitncnn_1 1324
+Convolution      Conv_622                 1 1 1324 1326 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_624               5 1 1315_splitncnn_2 1317_splitncnn_0 1320_splitncnn_0 1323_splitncnn_0 1326 1327
+Convolution      Conv_625                 1 1 1327 1328 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_628                  2 1 1328 1315_splitncnn_1 1331 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_148            1 6 1331 1331_splitncnn_0 1331_splitncnn_1 1331_splitncnn_2 1331_splitncnn_3 1331_splitncnn_4 1331_splitncnn_5
+Convolution      Conv_629                 1 1 1331_splitncnn_5 1333 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_149            1 4 1333 1333_splitncnn_0 1333_splitncnn_1 1333_splitncnn_2 1333_splitncnn_3
+Concat           Concat_631               2 1 1331_splitncnn_4 1333_splitncnn_3 1334
+Convolution      Conv_632                 1 1 1334 1336 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_150            1 3 1336 1336_splitncnn_0 1336_splitncnn_1 1336_splitncnn_2
+Concat           Concat_634               3 1 1331_splitncnn_3 1333_splitncnn_2 1336_splitncnn_2 1337
+Convolution      Conv_635                 1 1 1337 1339 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_151            1 2 1339 1339_splitncnn_0 1339_splitncnn_1
+Concat           Concat_637               4 1 1331_splitncnn_2 1333_splitncnn_1 1336_splitncnn_1 1339_splitncnn_1 1340
+Convolution      Conv_638                 1 1 1340 1342 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_640               5 1 1331_splitncnn_1 1333_splitncnn_0 1336_splitncnn_0 1339_splitncnn_0 1342 1343
+Convolution      Conv_641                 1 1 1343 1344 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_644                  2 1 1344 1331_splitncnn_0 1347 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_152            1 6 1347 1347_splitncnn_0 1347_splitncnn_1 1347_splitncnn_2 1347_splitncnn_3 1347_splitncnn_4 1347_splitncnn_5
+Convolution      Conv_645                 1 1 1347_splitncnn_5 1349 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_153            1 4 1349 1349_splitncnn_0 1349_splitncnn_1 1349_splitncnn_2 1349_splitncnn_3
+Concat           Concat_647               2 1 1347_splitncnn_4 1349_splitncnn_3 1350
+Convolution      Conv_648                 1 1 1350 1352 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_154            1 3 1352 1352_splitncnn_0 1352_splitncnn_1 1352_splitncnn_2
+Concat           Concat_650               3 1 1347_splitncnn_3 1349_splitncnn_2 1352_splitncnn_2 1353
+Convolution      Conv_651                 1 1 1353 1355 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_155            1 2 1355 1355_splitncnn_0 1355_splitncnn_1
+Concat           Concat_653               4 1 1347_splitncnn_2 1349_splitncnn_1 1352_splitncnn_1 1355_splitncnn_1 1356
+Convolution      Conv_654                 1 1 1356 1358 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_656               5 1 1347_splitncnn_1 1349_splitncnn_0 1352_splitncnn_0 1355_splitncnn_0 1358 1359
+Convolution      Conv_657                 1 1 1359 1360 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_660                  2 1 1360 1347_splitncnn_0 1363 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_663                  2 1 1363 1315_splitncnn_0 1366 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_156            1 7 1366 1366_splitncnn_0 1366_splitncnn_1 1366_splitncnn_2 1366_splitncnn_3 1366_splitncnn_4 1366_splitncnn_5 1366_splitncnn_6
+Convolution      Conv_664                 1 1 1366_splitncnn_6 1368 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_157            1 4 1368 1368_splitncnn_0 1368_splitncnn_1 1368_splitncnn_2 1368_splitncnn_3
+Concat           Concat_666               2 1 1366_splitncnn_5 1368_splitncnn_3 1369
+Convolution      Conv_667                 1 1 1369 1371 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_158            1 3 1371 1371_splitncnn_0 1371_splitncnn_1 1371_splitncnn_2
+Concat           Concat_669               3 1 1366_splitncnn_4 1368_splitncnn_2 1371_splitncnn_2 1372
+Convolution      Conv_670                 1 1 1372 1374 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_159            1 2 1374 1374_splitncnn_0 1374_splitncnn_1
+Concat           Concat_672               4 1 1366_splitncnn_3 1368_splitncnn_1 1371_splitncnn_1 1374_splitncnn_1 1375
+Convolution      Conv_673                 1 1 1375 1377 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_675               5 1 1366_splitncnn_2 1368_splitncnn_0 1371_splitncnn_0 1374_splitncnn_0 1377 1378
+Convolution      Conv_676                 1 1 1378 1379 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_679                  2 1 1379 1366_splitncnn_1 1382 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_160            1 6 1382 1382_splitncnn_0 1382_splitncnn_1 1382_splitncnn_2 1382_splitncnn_3 1382_splitncnn_4 1382_splitncnn_5
+Convolution      Conv_680                 1 1 1382_splitncnn_5 1384 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_161            1 4 1384 1384_splitncnn_0 1384_splitncnn_1 1384_splitncnn_2 1384_splitncnn_3
+Concat           Concat_682               2 1 1382_splitncnn_4 1384_splitncnn_3 1385
+Convolution      Conv_683                 1 1 1385 1387 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_162            1 3 1387 1387_splitncnn_0 1387_splitncnn_1 1387_splitncnn_2
+Concat           Concat_685               3 1 1382_splitncnn_3 1384_splitncnn_2 1387_splitncnn_2 1388
+Convolution      Conv_686                 1 1 1388 1390 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_163            1 2 1390 1390_splitncnn_0 1390_splitncnn_1
+Concat           Concat_688               4 1 1382_splitncnn_2 1384_splitncnn_1 1387_splitncnn_1 1390_splitncnn_1 1391
+Convolution      Conv_689                 1 1 1391 1393 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_691               5 1 1382_splitncnn_1 1384_splitncnn_0 1387_splitncnn_0 1390_splitncnn_0 1393 1394
+Convolution      Conv_692                 1 1 1394 1395 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_695                  2 1 1395 1382_splitncnn_0 1398 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_164            1 6 1398 1398_splitncnn_0 1398_splitncnn_1 1398_splitncnn_2 1398_splitncnn_3 1398_splitncnn_4 1398_splitncnn_5
+Convolution      Conv_696                 1 1 1398_splitncnn_5 1400 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_165            1 4 1400 1400_splitncnn_0 1400_splitncnn_1 1400_splitncnn_2 1400_splitncnn_3
+Concat           Concat_698               2 1 1398_splitncnn_4 1400_splitncnn_3 1401
+Convolution      Conv_699                 1 1 1401 1403 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_166            1 3 1403 1403_splitncnn_0 1403_splitncnn_1 1403_splitncnn_2
+Concat           Concat_701               3 1 1398_splitncnn_3 1400_splitncnn_2 1403_splitncnn_2 1404
+Convolution      Conv_702                 1 1 1404 1406 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_167            1 2 1406 1406_splitncnn_0 1406_splitncnn_1
+Concat           Concat_704               4 1 1398_splitncnn_2 1400_splitncnn_1 1403_splitncnn_1 1406_splitncnn_1 1407
+Convolution      Conv_705                 1 1 1407 1409 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_707               5 1 1398_splitncnn_1 1400_splitncnn_0 1403_splitncnn_0 1406_splitncnn_0 1409 1410
+Convolution      Conv_708                 1 1 1410 1411 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_711                  2 1 1411 1398_splitncnn_0 1414 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_714                  2 1 1414 1366_splitncnn_0 1417 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_168            1 7 1417 1417_splitncnn_0 1417_splitncnn_1 1417_splitncnn_2 1417_splitncnn_3 1417_splitncnn_4 1417_splitncnn_5 1417_splitncnn_6
+Convolution      Conv_715                 1 1 1417_splitncnn_6 1419 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_169            1 4 1419 1419_splitncnn_0 1419_splitncnn_1 1419_splitncnn_2 1419_splitncnn_3
+Concat           Concat_717               2 1 1417_splitncnn_5 1419_splitncnn_3 1420
+Convolution      Conv_718                 1 1 1420 1422 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_170            1 3 1422 1422_splitncnn_0 1422_splitncnn_1 1422_splitncnn_2
+Concat           Concat_720               3 1 1417_splitncnn_4 1419_splitncnn_2 1422_splitncnn_2 1423
+Convolution      Conv_721                 1 1 1423 1425 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_171            1 2 1425 1425_splitncnn_0 1425_splitncnn_1
+Concat           Concat_723               4 1 1417_splitncnn_3 1419_splitncnn_1 1422_splitncnn_1 1425_splitncnn_1 1426
+Convolution      Conv_724                 1 1 1426 1428 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_726               5 1 1417_splitncnn_2 1419_splitncnn_0 1422_splitncnn_0 1425_splitncnn_0 1428 1429
+Convolution      Conv_727                 1 1 1429 1430 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_730                  2 1 1430 1417_splitncnn_1 1433 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_172            1 6 1433 1433_splitncnn_0 1433_splitncnn_1 1433_splitncnn_2 1433_splitncnn_3 1433_splitncnn_4 1433_splitncnn_5
+Convolution      Conv_731                 1 1 1433_splitncnn_5 1435 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_173            1 4 1435 1435_splitncnn_0 1435_splitncnn_1 1435_splitncnn_2 1435_splitncnn_3
+Concat           Concat_733               2 1 1433_splitncnn_4 1435_splitncnn_3 1436
+Convolution      Conv_734                 1 1 1436 1438 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_174            1 3 1438 1438_splitncnn_0 1438_splitncnn_1 1438_splitncnn_2
+Concat           Concat_736               3 1 1433_splitncnn_3 1435_splitncnn_2 1438_splitncnn_2 1439
+Convolution      Conv_737                 1 1 1439 1441 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_175            1 2 1441 1441_splitncnn_0 1441_splitncnn_1
+Concat           Concat_739               4 1 1433_splitncnn_2 1435_splitncnn_1 1438_splitncnn_1 1441_splitncnn_1 1442
+Convolution      Conv_740                 1 1 1442 1444 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_742               5 1 1433_splitncnn_1 1435_splitncnn_0 1438_splitncnn_0 1441_splitncnn_0 1444 1445
+Convolution      Conv_743                 1 1 1445 1446 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_746                  2 1 1446 1433_splitncnn_0 1449 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_176            1 6 1449 1449_splitncnn_0 1449_splitncnn_1 1449_splitncnn_2 1449_splitncnn_3 1449_splitncnn_4 1449_splitncnn_5
+Convolution      Conv_747                 1 1 1449_splitncnn_5 1451 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_177            1 4 1451 1451_splitncnn_0 1451_splitncnn_1 1451_splitncnn_2 1451_splitncnn_3
+Concat           Concat_749               2 1 1449_splitncnn_4 1451_splitncnn_3 1452
+Convolution      Conv_750                 1 1 1452 1454 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_178            1 3 1454 1454_splitncnn_0 1454_splitncnn_1 1454_splitncnn_2
+Concat           Concat_752               3 1 1449_splitncnn_3 1451_splitncnn_2 1454_splitncnn_2 1455
+Convolution      Conv_753                 1 1 1455 1457 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_179            1 2 1457 1457_splitncnn_0 1457_splitncnn_1
+Concat           Concat_755               4 1 1449_splitncnn_2 1451_splitncnn_1 1454_splitncnn_1 1457_splitncnn_1 1458
+Convolution      Conv_756                 1 1 1458 1460 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_758               5 1 1449_splitncnn_1 1451_splitncnn_0 1454_splitncnn_0 1457_splitncnn_0 1460 1461
+Convolution      Conv_759                 1 1 1461 1462 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_762                  2 1 1462 1449_splitncnn_0 1465 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_765                  2 1 1465 1417_splitncnn_0 1468 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_180            1 7 1468 1468_splitncnn_0 1468_splitncnn_1 1468_splitncnn_2 1468_splitncnn_3 1468_splitncnn_4 1468_splitncnn_5 1468_splitncnn_6
+Convolution      Conv_766                 1 1 1468_splitncnn_6 1470 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_181            1 4 1470 1470_splitncnn_0 1470_splitncnn_1 1470_splitncnn_2 1470_splitncnn_3
+Concat           Concat_768               2 1 1468_splitncnn_5 1470_splitncnn_3 1471
+Convolution      Conv_769                 1 1 1471 1473 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_182            1 3 1473 1473_splitncnn_0 1473_splitncnn_1 1473_splitncnn_2
+Concat           Concat_771               3 1 1468_splitncnn_4 1470_splitncnn_2 1473_splitncnn_2 1474
+Convolution      Conv_772                 1 1 1474 1476 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_183            1 2 1476 1476_splitncnn_0 1476_splitncnn_1
+Concat           Concat_774               4 1 1468_splitncnn_3 1470_splitncnn_1 1473_splitncnn_1 1476_splitncnn_1 1477
+Convolution      Conv_775                 1 1 1477 1479 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_777               5 1 1468_splitncnn_2 1470_splitncnn_0 1473_splitncnn_0 1476_splitncnn_0 1479 1480
+Convolution      Conv_778                 1 1 1480 1481 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_781                  2 1 1481 1468_splitncnn_1 1484 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_184            1 6 1484 1484_splitncnn_0 1484_splitncnn_1 1484_splitncnn_2 1484_splitncnn_3 1484_splitncnn_4 1484_splitncnn_5
+Convolution      Conv_782                 1 1 1484_splitncnn_5 1486 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_185            1 4 1486 1486_splitncnn_0 1486_splitncnn_1 1486_splitncnn_2 1486_splitncnn_3
+Concat           Concat_784               2 1 1484_splitncnn_4 1486_splitncnn_3 1487
+Convolution      Conv_785                 1 1 1487 1489 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_186            1 3 1489 1489_splitncnn_0 1489_splitncnn_1 1489_splitncnn_2
+Concat           Concat_787               3 1 1484_splitncnn_3 1486_splitncnn_2 1489_splitncnn_2 1490
+Convolution      Conv_788                 1 1 1490 1492 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_187            1 2 1492 1492_splitncnn_0 1492_splitncnn_1
+Concat           Concat_790               4 1 1484_splitncnn_2 1486_splitncnn_1 1489_splitncnn_1 1492_splitncnn_1 1493
+Convolution      Conv_791                 1 1 1493 1495 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_793               5 1 1484_splitncnn_1 1486_splitncnn_0 1489_splitncnn_0 1492_splitncnn_0 1495 1496
+Convolution      Conv_794                 1 1 1496 1497 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_797                  2 1 1497 1484_splitncnn_0 1500 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_188            1 6 1500 1500_splitncnn_0 1500_splitncnn_1 1500_splitncnn_2 1500_splitncnn_3 1500_splitncnn_4 1500_splitncnn_5
+Convolution      Conv_798                 1 1 1500_splitncnn_5 1502 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_189            1 4 1502 1502_splitncnn_0 1502_splitncnn_1 1502_splitncnn_2 1502_splitncnn_3
+Concat           Concat_800               2 1 1500_splitncnn_4 1502_splitncnn_3 1503
+Convolution      Conv_801                 1 1 1503 1505 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_190            1 3 1505 1505_splitncnn_0 1505_splitncnn_1 1505_splitncnn_2
+Concat           Concat_803               3 1 1500_splitncnn_3 1502_splitncnn_2 1505_splitncnn_2 1506
+Convolution      Conv_804                 1 1 1506 1508 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_191            1 2 1508 1508_splitncnn_0 1508_splitncnn_1
+Concat           Concat_806               4 1 1500_splitncnn_2 1502_splitncnn_1 1505_splitncnn_1 1508_splitncnn_1 1509
+Convolution      Conv_807                 1 1 1509 1511 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_809               5 1 1500_splitncnn_1 1502_splitncnn_0 1505_splitncnn_0 1508_splitncnn_0 1511 1512
+Convolution      Conv_810                 1 1 1512 1513 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_813                  2 1 1513 1500_splitncnn_0 1516 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_816                  2 1 1516 1468_splitncnn_0 1519 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_192            1 7 1519 1519_splitncnn_0 1519_splitncnn_1 1519_splitncnn_2 1519_splitncnn_3 1519_splitncnn_4 1519_splitncnn_5 1519_splitncnn_6
+Convolution      Conv_817                 1 1 1519_splitncnn_6 1521 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_193            1 4 1521 1521_splitncnn_0 1521_splitncnn_1 1521_splitncnn_2 1521_splitncnn_3
+Concat           Concat_819               2 1 1519_splitncnn_5 1521_splitncnn_3 1522
+Convolution      Conv_820                 1 1 1522 1524 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_194            1 3 1524 1524_splitncnn_0 1524_splitncnn_1 1524_splitncnn_2
+Concat           Concat_822               3 1 1519_splitncnn_4 1521_splitncnn_2 1524_splitncnn_2 1525
+Convolution      Conv_823                 1 1 1525 1527 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_195            1 2 1527 1527_splitncnn_0 1527_splitncnn_1
+Concat           Concat_825               4 1 1519_splitncnn_3 1521_splitncnn_1 1524_splitncnn_1 1527_splitncnn_1 1528
+Convolution      Conv_826                 1 1 1528 1530 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_828               5 1 1519_splitncnn_2 1521_splitncnn_0 1524_splitncnn_0 1527_splitncnn_0 1530 1531
+Convolution      Conv_829                 1 1 1531 1532 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_832                  2 1 1532 1519_splitncnn_1 1535 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_196            1 6 1535 1535_splitncnn_0 1535_splitncnn_1 1535_splitncnn_2 1535_splitncnn_3 1535_splitncnn_4 1535_splitncnn_5
+Convolution      Conv_833                 1 1 1535_splitncnn_5 1537 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_197            1 4 1537 1537_splitncnn_0 1537_splitncnn_1 1537_splitncnn_2 1537_splitncnn_3
+Concat           Concat_835               2 1 1535_splitncnn_4 1537_splitncnn_3 1538
+Convolution      Conv_836                 1 1 1538 1540 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_198            1 3 1540 1540_splitncnn_0 1540_splitncnn_1 1540_splitncnn_2
+Concat           Concat_838               3 1 1535_splitncnn_3 1537_splitncnn_2 1540_splitncnn_2 1541
+Convolution      Conv_839                 1 1 1541 1543 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_199            1 2 1543 1543_splitncnn_0 1543_splitncnn_1
+Concat           Concat_841               4 1 1535_splitncnn_2 1537_splitncnn_1 1540_splitncnn_1 1543_splitncnn_1 1544
+Convolution      Conv_842                 1 1 1544 1546 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_844               5 1 1535_splitncnn_1 1537_splitncnn_0 1540_splitncnn_0 1543_splitncnn_0 1546 1547
+Convolution      Conv_845                 1 1 1547 1548 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_848                  2 1 1548 1535_splitncnn_0 1551 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_200            1 6 1551 1551_splitncnn_0 1551_splitncnn_1 1551_splitncnn_2 1551_splitncnn_3 1551_splitncnn_4 1551_splitncnn_5
+Convolution      Conv_849                 1 1 1551_splitncnn_5 1553 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_201            1 4 1553 1553_splitncnn_0 1553_splitncnn_1 1553_splitncnn_2 1553_splitncnn_3
+Concat           Concat_851               2 1 1551_splitncnn_4 1553_splitncnn_3 1554
+Convolution      Conv_852                 1 1 1554 1556 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_202            1 3 1556 1556_splitncnn_0 1556_splitncnn_1 1556_splitncnn_2
+Concat           Concat_854               3 1 1551_splitncnn_3 1553_splitncnn_2 1556_splitncnn_2 1557
+Convolution      Conv_855                 1 1 1557 1559 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_203            1 2 1559 1559_splitncnn_0 1559_splitncnn_1
+Concat           Concat_857               4 1 1551_splitncnn_2 1553_splitncnn_1 1556_splitncnn_1 1559_splitncnn_1 1560
+Convolution      Conv_858                 1 1 1560 1562 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_860               5 1 1551_splitncnn_1 1553_splitncnn_0 1556_splitncnn_0 1559_splitncnn_0 1562 1563
+Convolution      Conv_861                 1 1 1563 1564 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_864                  2 1 1564 1551_splitncnn_0 1567 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_867                  2 1 1567 1519_splitncnn_0 1570 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_204            1 7 1570 1570_splitncnn_0 1570_splitncnn_1 1570_splitncnn_2 1570_splitncnn_3 1570_splitncnn_4 1570_splitncnn_5 1570_splitncnn_6
+Convolution      Conv_868                 1 1 1570_splitncnn_6 1572 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_205            1 4 1572 1572_splitncnn_0 1572_splitncnn_1 1572_splitncnn_2 1572_splitncnn_3
+Concat           Concat_870               2 1 1570_splitncnn_5 1572_splitncnn_3 1573
+Convolution      Conv_871                 1 1 1573 1575 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_206            1 3 1575 1575_splitncnn_0 1575_splitncnn_1 1575_splitncnn_2
+Concat           Concat_873               3 1 1570_splitncnn_4 1572_splitncnn_2 1575_splitncnn_2 1576
+Convolution      Conv_874                 1 1 1576 1578 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_207            1 2 1578 1578_splitncnn_0 1578_splitncnn_1
+Concat           Concat_876               4 1 1570_splitncnn_3 1572_splitncnn_1 1575_splitncnn_1 1578_splitncnn_1 1579
+Convolution      Conv_877                 1 1 1579 1581 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_879               5 1 1570_splitncnn_2 1572_splitncnn_0 1575_splitncnn_0 1578_splitncnn_0 1581 1582
+Convolution      Conv_880                 1 1 1582 1583 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_883                  2 1 1583 1570_splitncnn_1 1586 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_208            1 6 1586 1586_splitncnn_0 1586_splitncnn_1 1586_splitncnn_2 1586_splitncnn_3 1586_splitncnn_4 1586_splitncnn_5
+Convolution      Conv_884                 1 1 1586_splitncnn_5 1588 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_209            1 4 1588 1588_splitncnn_0 1588_splitncnn_1 1588_splitncnn_2 1588_splitncnn_3
+Concat           Concat_886               2 1 1586_splitncnn_4 1588_splitncnn_3 1589
+Convolution      Conv_887                 1 1 1589 1591 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_210            1 3 1591 1591_splitncnn_0 1591_splitncnn_1 1591_splitncnn_2
+Concat           Concat_889               3 1 1586_splitncnn_3 1588_splitncnn_2 1591_splitncnn_2 1592
+Convolution      Conv_890                 1 1 1592 1594 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_211            1 2 1594 1594_splitncnn_0 1594_splitncnn_1
+Concat           Concat_892               4 1 1586_splitncnn_2 1588_splitncnn_1 1591_splitncnn_1 1594_splitncnn_1 1595
+Convolution      Conv_893                 1 1 1595 1597 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_895               5 1 1586_splitncnn_1 1588_splitncnn_0 1591_splitncnn_0 1594_splitncnn_0 1597 1598
+Convolution      Conv_896                 1 1 1598 1599 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_899                  2 1 1599 1586_splitncnn_0 1602 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_212            1 6 1602 1602_splitncnn_0 1602_splitncnn_1 1602_splitncnn_2 1602_splitncnn_3 1602_splitncnn_4 1602_splitncnn_5
+Convolution      Conv_900                 1 1 1602_splitncnn_5 1604 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_213            1 4 1604 1604_splitncnn_0 1604_splitncnn_1 1604_splitncnn_2 1604_splitncnn_3
+Concat           Concat_902               2 1 1602_splitncnn_4 1604_splitncnn_3 1605
+Convolution      Conv_903                 1 1 1605 1607 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_214            1 3 1607 1607_splitncnn_0 1607_splitncnn_1 1607_splitncnn_2
+Concat           Concat_905               3 1 1602_splitncnn_3 1604_splitncnn_2 1607_splitncnn_2 1608
+Convolution      Conv_906                 1 1 1608 1610 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_215            1 2 1610 1610_splitncnn_0 1610_splitncnn_1
+Concat           Concat_908               4 1 1602_splitncnn_2 1604_splitncnn_1 1607_splitncnn_1 1610_splitncnn_1 1611
+Convolution      Conv_909                 1 1 1611 1613 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_911               5 1 1602_splitncnn_1 1604_splitncnn_0 1607_splitncnn_0 1610_splitncnn_0 1613 1614
+Convolution      Conv_912                 1 1 1614 1615 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_915                  2 1 1615 1602_splitncnn_0 1618 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_918                  2 1 1618 1570_splitncnn_0 1621 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_216            1 7 1621 1621_splitncnn_0 1621_splitncnn_1 1621_splitncnn_2 1621_splitncnn_3 1621_splitncnn_4 1621_splitncnn_5 1621_splitncnn_6
+Convolution      Conv_919                 1 1 1621_splitncnn_6 1623 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_217            1 4 1623 1623_splitncnn_0 1623_splitncnn_1 1623_splitncnn_2 1623_splitncnn_3
+Concat           Concat_921               2 1 1621_splitncnn_5 1623_splitncnn_3 1624
+Convolution      Conv_922                 1 1 1624 1626 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_218            1 3 1626 1626_splitncnn_0 1626_splitncnn_1 1626_splitncnn_2
+Concat           Concat_924               3 1 1621_splitncnn_4 1623_splitncnn_2 1626_splitncnn_2 1627
+Convolution      Conv_925                 1 1 1627 1629 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_219            1 2 1629 1629_splitncnn_0 1629_splitncnn_1
+Concat           Concat_927               4 1 1621_splitncnn_3 1623_splitncnn_1 1626_splitncnn_1 1629_splitncnn_1 1630
+Convolution      Conv_928                 1 1 1630 1632 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_930               5 1 1621_splitncnn_2 1623_splitncnn_0 1626_splitncnn_0 1629_splitncnn_0 1632 1633
+Convolution      Conv_931                 1 1 1633 1634 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_934                  2 1 1634 1621_splitncnn_1 1637 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_220            1 6 1637 1637_splitncnn_0 1637_splitncnn_1 1637_splitncnn_2 1637_splitncnn_3 1637_splitncnn_4 1637_splitncnn_5
+Convolution      Conv_935                 1 1 1637_splitncnn_5 1639 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_221            1 4 1639 1639_splitncnn_0 1639_splitncnn_1 1639_splitncnn_2 1639_splitncnn_3
+Concat           Concat_937               2 1 1637_splitncnn_4 1639_splitncnn_3 1640
+Convolution      Conv_938                 1 1 1640 1642 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_222            1 3 1642 1642_splitncnn_0 1642_splitncnn_1 1642_splitncnn_2
+Concat           Concat_940               3 1 1637_splitncnn_3 1639_splitncnn_2 1642_splitncnn_2 1643
+Convolution      Conv_941                 1 1 1643 1645 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_223            1 2 1645 1645_splitncnn_0 1645_splitncnn_1
+Concat           Concat_943               4 1 1637_splitncnn_2 1639_splitncnn_1 1642_splitncnn_1 1645_splitncnn_1 1646
+Convolution      Conv_944                 1 1 1646 1648 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_946               5 1 1637_splitncnn_1 1639_splitncnn_0 1642_splitncnn_0 1645_splitncnn_0 1648 1649
+Convolution      Conv_947                 1 1 1649 1650 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_950                  2 1 1650 1637_splitncnn_0 1653 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_224            1 6 1653 1653_splitncnn_0 1653_splitncnn_1 1653_splitncnn_2 1653_splitncnn_3 1653_splitncnn_4 1653_splitncnn_5
+Convolution      Conv_951                 1 1 1653_splitncnn_5 1655 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_225            1 4 1655 1655_splitncnn_0 1655_splitncnn_1 1655_splitncnn_2 1655_splitncnn_3
+Concat           Concat_953               2 1 1653_splitncnn_4 1655_splitncnn_3 1656
+Convolution      Conv_954                 1 1 1656 1658 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_226            1 3 1658 1658_splitncnn_0 1658_splitncnn_1 1658_splitncnn_2
+Concat           Concat_956               3 1 1653_splitncnn_3 1655_splitncnn_2 1658_splitncnn_2 1659
+Convolution      Conv_957                 1 1 1659 1661 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_227            1 2 1661 1661_splitncnn_0 1661_splitncnn_1
+Concat           Concat_959               4 1 1653_splitncnn_2 1655_splitncnn_1 1658_splitncnn_1 1661_splitncnn_1 1662
+Convolution      Conv_960                 1 1 1662 1664 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_962               5 1 1653_splitncnn_1 1655_splitncnn_0 1658_splitncnn_0 1661_splitncnn_0 1664 1665
+Convolution      Conv_963                 1 1 1665 1666 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_966                  2 1 1666 1653_splitncnn_0 1669 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_969                  2 1 1669 1621_splitncnn_0 1672 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_228            1 7 1672 1672_splitncnn_0 1672_splitncnn_1 1672_splitncnn_2 1672_splitncnn_3 1672_splitncnn_4 1672_splitncnn_5 1672_splitncnn_6
+Convolution      Conv_970                 1 1 1672_splitncnn_6 1674 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_229            1 4 1674 1674_splitncnn_0 1674_splitncnn_1 1674_splitncnn_2 1674_splitncnn_3
+Concat           Concat_972               2 1 1672_splitncnn_5 1674_splitncnn_3 1675
+Convolution      Conv_973                 1 1 1675 1677 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_230            1 3 1677 1677_splitncnn_0 1677_splitncnn_1 1677_splitncnn_2
+Concat           Concat_975               3 1 1672_splitncnn_4 1674_splitncnn_2 1677_splitncnn_2 1678
+Convolution      Conv_976                 1 1 1678 1680 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_231            1 2 1680 1680_splitncnn_0 1680_splitncnn_1
+Concat           Concat_978               4 1 1672_splitncnn_3 1674_splitncnn_1 1677_splitncnn_1 1680_splitncnn_1 1681
+Convolution      Conv_979                 1 1 1681 1683 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_981               5 1 1672_splitncnn_2 1674_splitncnn_0 1677_splitncnn_0 1680_splitncnn_0 1683 1684
+Convolution      Conv_982                 1 1 1684 1685 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_985                  2 1 1685 1672_splitncnn_1 1688 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_232            1 6 1688 1688_splitncnn_0 1688_splitncnn_1 1688_splitncnn_2 1688_splitncnn_3 1688_splitncnn_4 1688_splitncnn_5
+Convolution      Conv_986                 1 1 1688_splitncnn_5 1690 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_233            1 4 1690 1690_splitncnn_0 1690_splitncnn_1 1690_splitncnn_2 1690_splitncnn_3
+Concat           Concat_988               2 1 1688_splitncnn_4 1690_splitncnn_3 1691
+Convolution      Conv_989                 1 1 1691 1693 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_234            1 3 1693 1693_splitncnn_0 1693_splitncnn_1 1693_splitncnn_2
+Concat           Concat_991               3 1 1688_splitncnn_3 1690_splitncnn_2 1693_splitncnn_2 1694
+Convolution      Conv_992                 1 1 1694 1696 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_235            1 2 1696 1696_splitncnn_0 1696_splitncnn_1
+Concat           Concat_994               4 1 1688_splitncnn_2 1690_splitncnn_1 1693_splitncnn_1 1696_splitncnn_1 1697
+Convolution      Conv_995                 1 1 1697 1699 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_997               5 1 1688_splitncnn_1 1690_splitncnn_0 1693_splitncnn_0 1696_splitncnn_0 1699 1700
+Convolution      Conv_998                 1 1 1700 1701 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1001                 2 1 1701 1688_splitncnn_0 1704 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_236            1 6 1704 1704_splitncnn_0 1704_splitncnn_1 1704_splitncnn_2 1704_splitncnn_3 1704_splitncnn_4 1704_splitncnn_5
+Convolution      Conv_1002                1 1 1704_splitncnn_5 1706 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_237            1 4 1706 1706_splitncnn_0 1706_splitncnn_1 1706_splitncnn_2 1706_splitncnn_3
+Concat           Concat_1004              2 1 1704_splitncnn_4 1706_splitncnn_3 1707
+Convolution      Conv_1005                1 1 1707 1709 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_238            1 3 1709 1709_splitncnn_0 1709_splitncnn_1 1709_splitncnn_2
+Concat           Concat_1007              3 1 1704_splitncnn_3 1706_splitncnn_2 1709_splitncnn_2 1710
+Convolution      Conv_1008                1 1 1710 1712 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_239            1 2 1712 1712_splitncnn_0 1712_splitncnn_1
+Concat           Concat_1010              4 1 1704_splitncnn_2 1706_splitncnn_1 1709_splitncnn_1 1712_splitncnn_1 1713
+Convolution      Conv_1011                1 1 1713 1715 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1013              5 1 1704_splitncnn_1 1706_splitncnn_0 1709_splitncnn_0 1712_splitncnn_0 1715 1716
+Convolution      Conv_1014                1 1 1716 1717 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1017                 2 1 1717 1704_splitncnn_0 1720 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_1020                 2 1 1720 1672_splitncnn_0 1723 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_240            1 7 1723 1723_splitncnn_0 1723_splitncnn_1 1723_splitncnn_2 1723_splitncnn_3 1723_splitncnn_4 1723_splitncnn_5 1723_splitncnn_6
+Convolution      Conv_1021                1 1 1723_splitncnn_6 1725 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_241            1 4 1725 1725_splitncnn_0 1725_splitncnn_1 1725_splitncnn_2 1725_splitncnn_3
+Concat           Concat_1023              2 1 1723_splitncnn_5 1725_splitncnn_3 1726
+Convolution      Conv_1024                1 1 1726 1728 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_242            1 3 1728 1728_splitncnn_0 1728_splitncnn_1 1728_splitncnn_2
+Concat           Concat_1026              3 1 1723_splitncnn_4 1725_splitncnn_2 1728_splitncnn_2 1729
+Convolution      Conv_1027                1 1 1729 1731 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_243            1 2 1731 1731_splitncnn_0 1731_splitncnn_1
+Concat           Concat_1029              4 1 1723_splitncnn_3 1725_splitncnn_1 1728_splitncnn_1 1731_splitncnn_1 1732
+Convolution      Conv_1030                1 1 1732 1734 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1032              5 1 1723_splitncnn_2 1725_splitncnn_0 1728_splitncnn_0 1731_splitncnn_0 1734 1735
+Convolution      Conv_1033                1 1 1735 1736 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1036                 2 1 1736 1723_splitncnn_1 1739 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_244            1 6 1739 1739_splitncnn_0 1739_splitncnn_1 1739_splitncnn_2 1739_splitncnn_3 1739_splitncnn_4 1739_splitncnn_5
+Convolution      Conv_1037                1 1 1739_splitncnn_5 1741 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_245            1 4 1741 1741_splitncnn_0 1741_splitncnn_1 1741_splitncnn_2 1741_splitncnn_3
+Concat           Concat_1039              2 1 1739_splitncnn_4 1741_splitncnn_3 1742
+Convolution      Conv_1040                1 1 1742 1744 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_246            1 3 1744 1744_splitncnn_0 1744_splitncnn_1 1744_splitncnn_2
+Concat           Concat_1042              3 1 1739_splitncnn_3 1741_splitncnn_2 1744_splitncnn_2 1745
+Convolution      Conv_1043                1 1 1745 1747 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_247            1 2 1747 1747_splitncnn_0 1747_splitncnn_1
+Concat           Concat_1045              4 1 1739_splitncnn_2 1741_splitncnn_1 1744_splitncnn_1 1747_splitncnn_1 1748
+Convolution      Conv_1046                1 1 1748 1750 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1048              5 1 1739_splitncnn_1 1741_splitncnn_0 1744_splitncnn_0 1747_splitncnn_0 1750 1751
+Convolution      Conv_1049                1 1 1751 1752 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1052                 2 1 1752 1739_splitncnn_0 1755 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_248            1 6 1755 1755_splitncnn_0 1755_splitncnn_1 1755_splitncnn_2 1755_splitncnn_3 1755_splitncnn_4 1755_splitncnn_5
+Convolution      Conv_1053                1 1 1755_splitncnn_5 1757 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_249            1 4 1757 1757_splitncnn_0 1757_splitncnn_1 1757_splitncnn_2 1757_splitncnn_3
+Concat           Concat_1055              2 1 1755_splitncnn_4 1757_splitncnn_3 1758
+Convolution      Conv_1056                1 1 1758 1760 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_250            1 3 1760 1760_splitncnn_0 1760_splitncnn_1 1760_splitncnn_2
+Concat           Concat_1058              3 1 1755_splitncnn_3 1757_splitncnn_2 1760_splitncnn_2 1761
+Convolution      Conv_1059                1 1 1761 1763 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_251            1 2 1763 1763_splitncnn_0 1763_splitncnn_1
+Concat           Concat_1061              4 1 1755_splitncnn_2 1757_splitncnn_1 1760_splitncnn_1 1763_splitncnn_1 1764
+Convolution      Conv_1062                1 1 1764 1766 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1064              5 1 1755_splitncnn_1 1757_splitncnn_0 1760_splitncnn_0 1763_splitncnn_0 1766 1767
+Convolution      Conv_1065                1 1 1767 1768 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1068                 2 1 1768 1755_splitncnn_0 1771 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_1071                 2 1 1771 1723_splitncnn_0 1774 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_252            1 7 1774 1774_splitncnn_0 1774_splitncnn_1 1774_splitncnn_2 1774_splitncnn_3 1774_splitncnn_4 1774_splitncnn_5 1774_splitncnn_6
+Convolution      Conv_1072                1 1 1774_splitncnn_6 1776 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_253            1 4 1776 1776_splitncnn_0 1776_splitncnn_1 1776_splitncnn_2 1776_splitncnn_3
+Concat           Concat_1074              2 1 1774_splitncnn_5 1776_splitncnn_3 1777
+Convolution      Conv_1075                1 1 1777 1779 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_254            1 3 1779 1779_splitncnn_0 1779_splitncnn_1 1779_splitncnn_2
+Concat           Concat_1077              3 1 1774_splitncnn_4 1776_splitncnn_2 1779_splitncnn_2 1780
+Convolution      Conv_1078                1 1 1780 1782 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_255            1 2 1782 1782_splitncnn_0 1782_splitncnn_1
+Concat           Concat_1080              4 1 1774_splitncnn_3 1776_splitncnn_1 1779_splitncnn_1 1782_splitncnn_1 1783
+Convolution      Conv_1081                1 1 1783 1785 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1083              5 1 1774_splitncnn_2 1776_splitncnn_0 1779_splitncnn_0 1782_splitncnn_0 1785 1786
+Convolution      Conv_1084                1 1 1786 1787 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1087                 2 1 1787 1774_splitncnn_1 1790 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_256            1 6 1790 1790_splitncnn_0 1790_splitncnn_1 1790_splitncnn_2 1790_splitncnn_3 1790_splitncnn_4 1790_splitncnn_5
+Convolution      Conv_1088                1 1 1790_splitncnn_5 1792 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_257            1 4 1792 1792_splitncnn_0 1792_splitncnn_1 1792_splitncnn_2 1792_splitncnn_3
+Concat           Concat_1090              2 1 1790_splitncnn_4 1792_splitncnn_3 1793
+Convolution      Conv_1091                1 1 1793 1795 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_258            1 3 1795 1795_splitncnn_0 1795_splitncnn_1 1795_splitncnn_2
+Concat           Concat_1093              3 1 1790_splitncnn_3 1792_splitncnn_2 1795_splitncnn_2 1796
+Convolution      Conv_1094                1 1 1796 1798 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_259            1 2 1798 1798_splitncnn_0 1798_splitncnn_1
+Concat           Concat_1096              4 1 1790_splitncnn_2 1792_splitncnn_1 1795_splitncnn_1 1798_splitncnn_1 1799
+Convolution      Conv_1097                1 1 1799 1801 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1099              5 1 1790_splitncnn_1 1792_splitncnn_0 1795_splitncnn_0 1798_splitncnn_0 1801 1802
+Convolution      Conv_1100                1 1 1802 1803 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1103                 2 1 1803 1790_splitncnn_0 1806 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_260            1 6 1806 1806_splitncnn_0 1806_splitncnn_1 1806_splitncnn_2 1806_splitncnn_3 1806_splitncnn_4 1806_splitncnn_5
+Convolution      Conv_1104                1 1 1806_splitncnn_5 1808 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_261            1 4 1808 1808_splitncnn_0 1808_splitncnn_1 1808_splitncnn_2 1808_splitncnn_3
+Concat           Concat_1106              2 1 1806_splitncnn_4 1808_splitncnn_3 1809
+Convolution      Conv_1107                1 1 1809 1811 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_262            1 3 1811 1811_splitncnn_0 1811_splitncnn_1 1811_splitncnn_2
+Concat           Concat_1109              3 1 1806_splitncnn_3 1808_splitncnn_2 1811_splitncnn_2 1812
+Convolution      Conv_1110                1 1 1812 1814 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_263            1 2 1814 1814_splitncnn_0 1814_splitncnn_1
+Concat           Concat_1112              4 1 1806_splitncnn_2 1808_splitncnn_1 1811_splitncnn_1 1814_splitncnn_1 1815
+Convolution      Conv_1113                1 1 1815 1817 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1115              5 1 1806_splitncnn_1 1808_splitncnn_0 1811_splitncnn_0 1814_splitncnn_0 1817 1818
+Convolution      Conv_1116                1 1 1818 1819 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1119                 2 1 1819 1806_splitncnn_0 1822 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_1122                 2 1 1822 1774_splitncnn_0 1825 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_264            1 7 1825 1825_splitncnn_0 1825_splitncnn_1 1825_splitncnn_2 1825_splitncnn_3 1825_splitncnn_4 1825_splitncnn_5 1825_splitncnn_6
+Convolution      Conv_1123                1 1 1825_splitncnn_6 1827 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_265            1 4 1827 1827_splitncnn_0 1827_splitncnn_1 1827_splitncnn_2 1827_splitncnn_3
+Concat           Concat_1125              2 1 1825_splitncnn_5 1827_splitncnn_3 1828
+Convolution      Conv_1126                1 1 1828 1830 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_266            1 3 1830 1830_splitncnn_0 1830_splitncnn_1 1830_splitncnn_2
+Concat           Concat_1128              3 1 1825_splitncnn_4 1827_splitncnn_2 1830_splitncnn_2 1831
+Convolution      Conv_1129                1 1 1831 1833 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_267            1 2 1833 1833_splitncnn_0 1833_splitncnn_1
+Concat           Concat_1131              4 1 1825_splitncnn_3 1827_splitncnn_1 1830_splitncnn_1 1833_splitncnn_1 1834
+Convolution      Conv_1132                1 1 1834 1836 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1134              5 1 1825_splitncnn_2 1827_splitncnn_0 1830_splitncnn_0 1833_splitncnn_0 1836 1837
+Convolution      Conv_1135                1 1 1837 1838 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1138                 2 1 1838 1825_splitncnn_1 1841 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_268            1 6 1841 1841_splitncnn_0 1841_splitncnn_1 1841_splitncnn_2 1841_splitncnn_3 1841_splitncnn_4 1841_splitncnn_5
+Convolution      Conv_1139                1 1 1841_splitncnn_5 1843 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_269            1 4 1843 1843_splitncnn_0 1843_splitncnn_1 1843_splitncnn_2 1843_splitncnn_3
+Concat           Concat_1141              2 1 1841_splitncnn_4 1843_splitncnn_3 1844
+Convolution      Conv_1142                1 1 1844 1846 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_270            1 3 1846 1846_splitncnn_0 1846_splitncnn_1 1846_splitncnn_2
+Concat           Concat_1144              3 1 1841_splitncnn_3 1843_splitncnn_2 1846_splitncnn_2 1847
+Convolution      Conv_1145                1 1 1847 1849 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_271            1 2 1849 1849_splitncnn_0 1849_splitncnn_1
+Concat           Concat_1147              4 1 1841_splitncnn_2 1843_splitncnn_1 1846_splitncnn_1 1849_splitncnn_1 1850
+Convolution      Conv_1148                1 1 1850 1852 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1150              5 1 1841_splitncnn_1 1843_splitncnn_0 1846_splitncnn_0 1849_splitncnn_0 1852 1853
+Convolution      Conv_1151                1 1 1853 1854 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1154                 2 1 1854 1841_splitncnn_0 1857 0=1 -23301=2,2.000000e-01,1.000000e+00
+Split            splitncnn_272            1 6 1857 1857_splitncnn_0 1857_splitncnn_1 1857_splitncnn_2 1857_splitncnn_3 1857_splitncnn_4 1857_splitncnn_5
+Convolution      Conv_1155                1 1 1857_splitncnn_5 1859 0=32 1=3 4=1 5=1 6=18432 9=2 -23310=1,2.000000e-01
+Split            splitncnn_273            1 4 1859 1859_splitncnn_0 1859_splitncnn_1 1859_splitncnn_2 1859_splitncnn_3
+Concat           Concat_1157              2 1 1857_splitncnn_4 1859_splitncnn_3 1860
+Convolution      Conv_1158                1 1 1860 1862 0=32 1=3 4=1 5=1 6=27648 9=2 -23310=1,2.000000e-01
+Split            splitncnn_274            1 3 1862 1862_splitncnn_0 1862_splitncnn_1 1862_splitncnn_2
+Concat           Concat_1160              3 1 1857_splitncnn_3 1859_splitncnn_2 1862_splitncnn_2 1863
+Convolution      Conv_1161                1 1 1863 1865 0=32 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Split            splitncnn_275            1 2 1865 1865_splitncnn_0 1865_splitncnn_1
+Concat           Concat_1163              4 1 1857_splitncnn_2 1859_splitncnn_1 1862_splitncnn_1 1865_splitncnn_1 1866
+Convolution      Conv_1164                1 1 1866 1868 0=32 1=3 4=1 5=1 6=46080 9=2 -23310=1,2.000000e-01
+Concat           Concat_1166              5 1 1857_splitncnn_1 1859_splitncnn_0 1862_splitncnn_0 1865_splitncnn_0 1868 1869
+Convolution      Conv_1167                1 1 1869 1870 0=64 1=3 4=1 5=1 6=110592
+Eltwise          Add_1170                 2 1 1870 1857_splitncnn_0 1873 0=1 -23301=2,2.000000e-01,1.000000e+00
+Eltwise          Add_1173                 2 1 1873 1825_splitncnn_0 1876 0=1 -23301=2,2.000000e-01,1.000000e+00
+Convolution      Conv_1174                1 1 1876 1877 0=64 1=3 4=1 5=1 6=36864
+BinaryOp         Add_1175                 2 1 703_splitncnn_0 1877 1878
+Interp           Resize_1176              1 1 1878 1883 0=1 1=2.000000e+00 2=2.000000e+00
+Convolution      Conv_1177                1 1 1883 1885 0=64 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Interp           Resize_1179              1 1 1885 1890 0=1 1=2.000000e+00 2=2.000000e+00
+Convolution      Conv_1180                1 1 1890 1892 0=64 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Convolution      Conv_1182                1 1 1892 1894 0=64 1=3 4=1 5=1 6=36864 9=2 -23310=1,2.000000e-01
+Convolution      Conv_1184                1 1 1894 output 0=3 1=3 4=1 5=1 6=1728

--- a/models/upscayl-nmkd-4x-superscale-sd-178000-g.sh
+++ b/models/upscayl-nmkd-4x-superscale-sd-178000-g.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+model_name="Upscayl's NKMD Superscale SD 178000G x4 Upscaling"
+model_max_scale=4


### PR DESCRIPTION
Upscayl's team added a new model called
"4x_NMKD-Superscale-SP_178000_G". Let's port it in.

This patch adds upscayl-nmkd-4x-superscale-sd-178000-g into models/ directory.