### PR TITLE
init: added upscaler's host system verification

### DIFF
--- a/init/services/compilers/upscaler.ps1
+++ b/init/services/compilers/upscaler.ps1
@@ -27,96 +27,21 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-function OS-Is-Command-Available {
-	param (
-		[string]$__command
-	)
+. "${env:LIBS_UPSCALER}\services\io\os.ps1"
 
 
-	# validate input
-	if ([string]::IsNullOrEmpty($__command)) {
+
+
+function UPSCALER-Is-Available {
+	if (-not (OS-Host-System -eq "windows")) {
+		return 1
+	}
+
+	if (-not (OS-Host-Arch -eq "windows")) {
 		return 1
 	}
 
 
-	# execute
-	$__program = Get-Command $__command -ErrorAction SilentlyContinue
-	if ($__program) {
-		return 0
-	}
-	return 1
-}
-
-
-
-
-function OS-Exec {
-	param (
-		[string]$__command,
-		[string]$__arguments
-	)
-
-
-	# validate input
-	if ([string]::IsNullOrEmpty($__command) -or [string]::IsNullOrEmpty($__arguments)) {
-		return 1
-	}
-
-
-	# get program
-	$__program = Get-Command $__command -ErrorAction SilentlyContinue
-	if (-not ($__program)) {
-		return 1
-	}
-
-
-	# execute command
-	$__process = Start-Process -Wait `
-				-FilePath "$__program" `
-				-NoNewWindow `
-				-ArgumentList "$__arguments" `
-				-PassThru
-	if ($__process.ExitCode -ne 0) {
-		return 1
-	}
+	# report status
 	return 0
-}
-
-
-
-
-function OS-Host-Arch {
-	# execute
-	switch ((Get-ComputerInfo).CsProcessors.Architecture) {
-	"Alpha" {
-		return "alpha"
-	} "ARM" {
-		return "arm"
-	} "ARM64" {
-		return "arm64"
-	} "ia64" {
-		return "ia64"
-	} "MIPs" {
-		return "mips"
-	} "PowerPC" {
-		return "powerpc"
-	} "x86" {
-		return "i386"
-	} "x64" {
-		return "amd64"
-	} Default {
-		return ""
-	}}
-}
-
-
-
-
-function OS-Host-System {
-	$__os = (Get-ComputerInfo).OsName.ToLower()
-	if (-not ($__os -match "microsoft" -or $__os -match "windows")) {
-		return ""
-	}
-
-	return "windows"
 }

--- a/init/services/compilers/upscaler.sh
+++ b/init/services/compilers/upscaler.sh
@@ -1,6 +1,8 @@
+#!/bin/sh
+#
 # BSD 3-Clause License
 #
-# Copyright (c) 2024, (Holloway) Chew, Kean Ho
+# Copyright (c) 2023, (Holloway) Chew, Kean Ho
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,96 +29,30 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-function OS-Is-Command-Available {
-	param (
-		[string]$__command
-	)
-
-
-	# validate input
-	if ([string]::IsNullOrEmpty($__command)) {
-		return 1
-	}
-
-
-	# execute
-	$__program = Get-Command $__command -ErrorAction SilentlyContinue
-	if ($__program) {
-		return 0
-	}
-	return 1
-}
+. "${LIBS_UPSCALER}/services/io/os.sh"
 
 
 
 
-function OS-Exec {
-	param (
-		[string]$__command,
-		[string]$__arguments
-	)
+UPSCALER_Is_Available() {
+        case "$(OS_Host_System)" in
+        linux|darwin)
+                ;;
+        *)
+                return 1
+                ;;
+        esac
 
 
-	# validate input
-	if ([string]::IsNullOrEmpty($__command) -or [string]::IsNullOrEmpty($__arguments)) {
-		return 1
-	}
+        case "$(OS_Host_Arch)" in
+        amd64)
+                ;;
+        *)
+                return 1
+                ;;
+        esac
 
 
-	# get program
-	$__program = Get-Command $__command -ErrorAction SilentlyContinue
-	if (-not ($__program)) {
-		return 1
-	}
-
-
-	# execute command
-	$__process = Start-Process -Wait `
-				-FilePath "$__program" `
-				-NoNewWindow `
-				-ArgumentList "$__arguments" `
-				-PassThru
-	if ($__process.ExitCode -ne 0) {
-		return 1
-	}
-	return 0
-}
-
-
-
-
-function OS-Host-Arch {
-	# execute
-	switch ((Get-ComputerInfo).CsProcessors.Architecture) {
-	"Alpha" {
-		return "alpha"
-	} "ARM" {
-		return "arm"
-	} "ARM64" {
-		return "arm64"
-	} "ia64" {
-		return "ia64"
-	} "MIPs" {
-		return "mips"
-	} "PowerPC" {
-		return "powerpc"
-	} "x86" {
-		return "i386"
-	} "x64" {
-		return "amd64"
-	} Default {
-		return ""
-	}}
-}
-
-
-
-
-function OS-Host-System {
-	$__os = (Get-ComputerInfo).OsName.ToLower()
-	if (-not ($__os -match "microsoft" -or $__os -match "windows")) {
-		return ""
-	}
-
-	return "windows"
+        # report status
+        return 0
 }

--- a/init/services/i18n/error-unsupported.ps1
+++ b/init/services/i18n/error-unsupported.ps1
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 #
-# Copyright (c) 2024, (Holloway) Chew, Kean Ho
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,96 +27,23 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-function OS-Is-Command-Available {
-	param (
-		[string]$__command
-	)
+. "${env:LIBS_UPSCALER}\services\i18n\__printer.ps1"
 
 
-	# validate input
-	if ([string]::IsNullOrEmpty($__command)) {
-		return 1
-	}
 
 
+function I18N-Status-Error-Unsupported {
 	# execute
-	$__program = Get-Command $__command -ErrorAction SilentlyContinue
-	if ($__program) {
-		return 0
-	}
-	return 1
-}
-
-
-
-
-function OS-Exec {
-	param (
-		[string]$__command,
-		[string]$__arguments
-	)
-
-
-	# validate input
-	if ([string]::IsNullOrEmpty($__command) -or [string]::IsNullOrEmpty($__arguments)) {
-		return 1
-	}
-
-
-	# get program
-	$__program = Get-Command $__command -ErrorAction SilentlyContinue
-	if (-not ($__program)) {
-		return 1
-	}
-
-
-	# execute command
-	$__process = Start-Process -Wait `
-				-FilePath "$__program" `
-				-NoNewWindow `
-				-ArgumentList "$__arguments" `
-				-PassThru
-	if ($__process.ExitCode -ne 0) {
-		return 1
-	}
-	return 0
-}
-
-
-
-
-function OS-Host-Arch {
-	# execute
-	switch ((Get-ComputerInfo).CsProcessors.Architecture) {
-	"Alpha" {
-		return "alpha"
-	} "ARM" {
-		return "arm"
-	} "ARM64" {
-		return "arm64"
-	} "ia64" {
-		return "ia64"
-	} "MIPs" {
-		return "mips"
-	} "PowerPC" {
-		return "powerpc"
-	} "x86" {
-		return "i386"
-	} "x64" {
-		return "amd64"
-	} Default {
-		return ""
+	switch (${env:UPSCALER_LANG}) {
+	{ $_ -in "DE", "de" } {
+		# german
+		$null = I18N-Status-Print "error" "OS / Arch wird nicht unterstützt.`n"
+	} default {
+		# fallback to default english
+		$null = I18N-Status-Print "error" "OS / Arch is unsupported.`n"
 	}}
-}
 
 
-
-
-function OS-Host-System {
-	$__os = (Get-ComputerInfo).OsName.ToLower()
-	if (-not ($__os -match "microsoft" -or $__os -match "windows")) {
-		return ""
-	}
-
-	return "windows"
+	# report status
+	return 0
 }

--- a/init/services/i18n/error-unsupported.sh
+++ b/init/services/i18n/error-unsupported.sh
@@ -1,6 +1,6 @@
 # BSD 3-Clause License
 #
-# Copyright (c) 2024, (Holloway) Chew, Kean Ho
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,96 +27,25 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-function OS-Is-Command-Available {
-	param (
-		[string]$__command
-	)
-
-
-	# validate input
-	if ([string]::IsNullOrEmpty($__command)) {
-		return 1
-	}
-
-
-	# execute
-	$__program = Get-Command $__command -ErrorAction SilentlyContinue
-	if ($__program) {
-		return 0
-	}
-	return 1
-}
+. "${LIBS_UPSCALER}/services/i18n/__printer.sh"
 
 
 
 
-function OS-Exec {
-	param (
-		[string]$__command,
-		[string]$__arguments
-	)
+I18N_Status_Error_Unsupported() {
+        # execute
+        case "$UPSCALER_LANG" in
+        DE|de)
+                # German
+                I18N_Status_Print "error" "OS / Arch wird nicht unterstützt.\n"
+                ;;
+        *)
+                # fallback to default english
+                I18N_Status_Print "error" "OS / Arch is unsupported.\n"
+                ;;
+        esac
 
 
-	# validate input
-	if ([string]::IsNullOrEmpty($__command) -or [string]::IsNullOrEmpty($__arguments)) {
-		return 1
-	}
-
-
-	# get program
-	$__program = Get-Command $__command -ErrorAction SilentlyContinue
-	if (-not ($__program)) {
-		return 1
-	}
-
-
-	# execute command
-	$__process = Start-Process -Wait `
-				-FilePath "$__program" `
-				-NoNewWindow `
-				-ArgumentList "$__arguments" `
-				-PassThru
-	if ($__process.ExitCode -ne 0) {
-		return 1
-	}
-	return 0
-}
-
-
-
-
-function OS-Host-Arch {
-	# execute
-	switch ((Get-ComputerInfo).CsProcessors.Architecture) {
-	"Alpha" {
-		return "alpha"
-	} "ARM" {
-		return "arm"
-	} "ARM64" {
-		return "arm64"
-	} "ia64" {
-		return "ia64"
-	} "MIPs" {
-		return "mips"
-	} "PowerPC" {
-		return "powerpc"
-	} "x86" {
-		return "i386"
-	} "x64" {
-		return "amd64"
-	} Default {
-		return ""
-	}}
-}
-
-
-
-
-function OS-Host-System {
-	$__os = (Get-ComputerInfo).OsName.ToLower()
-	if (-not ($__os -match "microsoft" -or $__os -match "windows")) {
-		return ""
-	}
-
-	return "windows"
+        # report status
+        return 0
 }

--- a/init/services/io/os.sh
+++ b/init/services/io/os.sh
@@ -43,3 +43,73 @@ OS_Is_Command_Available() {
         fi
         return 1
 }
+
+
+
+
+OS_Host_Arch() {
+        __arch="$(printf "$(uname -m)" | tr '[:upper:]' '[:lower:]')"
+        case "${__arch}" in
+        i686-64)
+                __arch='ia64' # Intel Itanium.
+                ;;
+        i386|i486|i586|i686)
+                __arch='i386'
+                ;;
+        x86_64)
+                __arch="amd64"
+                ;;
+        sun4u)
+                __arch='sparc'
+                ;;
+        "power macintosh")
+                __arch='powerpc'
+                ;;
+        ip*)
+                __arch='mips'
+                ;;
+        *)
+                ;;
+        esac
+        printf -- "%s" "$__arch"
+
+
+        # report status
+        if [ -z "$__arch" ]; then
+                return 1
+        fi
+
+        return 0
+}
+
+
+
+
+OS_Host_System() {
+        __os="$(echo "$(uname)" | tr '[:upper:]' '[:lower:]')"
+        case "$__os" in
+        windows*|ms-dos*)
+                __os='windows'
+                ;;
+        cygwin*|mingw*|mingw32*|msys*)
+                __os='windows'
+                ;;
+        *freebsd)
+                __os='freebsd'
+                ;;
+        dragonfly*)
+                __os='dragonfly'
+                ;;
+        *)
+                ;;
+        esac
+        printf -- "%s" "$__os"
+
+
+        # report status
+        if [ -z "$__os" ]; then
+                return 1
+        fi
+
+        return 0
+}

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -91,6 +91,8 @@ ${env:LIBS_UPSCALER} = "${env:UPSCALER_PATH_ROOT}\${env:UPSCALER_PATH_SCRIPTS}"
 
 # import fundamental libraries
 . "${env:LIBS_UPSCALER}\services\io\strings.ps1"
+. "${env:LIBS_UPSCALER}\services\compilers\upscaler.ps1"
+. "${env:LIBS_UPSCALER}\services\i18n\error-unsupported.ps1"
 . "${env:LIBS_UPSCALER}\services\i18n\help.ps1"
 
 
@@ -152,10 +154,27 @@ for ($i = 0; $i -lt $args.Length; $i++) {
 	}}
 }
 
+
+
+
+# serve help printout and then bail out
 if ($__help -eq $true) {
 	$null = I18N-Status-Print-Help
 	exit 0
 }
 
 
+
+
+# verify host system is supported
+$__process = UPSCALER-Is-Available
+if ($__process -ne 0) {
+	$null = I18N-Status-Error-Unsupported
+	exit 1
+}
+
+
+
+
+# placeholder
 Write-Host "DEBUG: Model='${__model}' Scale='${__scale}' Format='${__format}' Parallel='${__parallel}' Video='${__video}' Input='${__input}' Output='${__output}' GPU='${__gpu}'"

--- a/init/start.sh
+++ b/init/start.sh
@@ -83,6 +83,8 @@ export LIBS_UPSCALER="${UPSCALER_PATH_ROOT}/${UPSCALER_PATH_SCRIPTS}"
 
 # import fundamental libraries
 . "${LIBS_UPSCALER}/services/io/strings.sh"
+. "${LIBS_UPSCALER}/services/compilers/upscaler.sh"
+. "${LIBS_UPSCALER}/services/i18n/error-unsupported.sh"
 . "${LIBS_UPSCALER}/services/i18n/help.sh"
 
 
@@ -153,11 +155,29 @@ while [ -n "$1" ]; do
         shift 1
 done
 
+
+
+
+# serve help printout and then bail out
 if [ "$__help" == "true" ]; then
         I18N_Status_Print_Help
         exit 0
 fi
 
+
+
+
+# verify host system is supported
+UPSCALER_Is_Available
+if [ $? -ne 0 ]; then
+        I18N_Status_Error_Unsupported
+        exit 1
+fi
+
+
+
+
+# placeholder
 printf "DEBUG model='%s' scale='%s' format='%s' parallel='%s' video='%s' input='%s' output='%s' gpu='%s' \n" \
         "$__model" \
         "$__scale" \


### PR DESCRIPTION
To make sure the upscaler's host system is checked before execution, it's best we port the OS + Arch system verifications into the new scripting libraries. Hence, let's do this.

This patch adds upscaler's host system verification into the init/ directory.