### PR TITLE
init: added input target validator

### DIFF
--- a/init/services/i18n/error-input-unknown.ps1
+++ b/init/services/i18n/error-input-unknown.ps1
@@ -1,0 +1,49 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_UPSCALER}\services\i18n\__printer.ps1"
+
+
+
+
+function I18N-Status-Error-Input-Unknown {
+	# execute
+	switch (${env:UPSCALER_LANG}) {
+	{ $_ -in "DE", "de" } {
+		# german
+		$null = I18N-Status-Print "error" "Unbekanntes/fehlendes Eingabeziel.`n"
+	} default {
+		# fallback to default english
+		$null = I18N-Status-Print "error" "Unknown/missing input target.`n"
+	}}
+
+
+	# report status
+	return 0
+}

--- a/init/services/i18n/error-input-unknown.sh
+++ b/init/services/i18n/error-input-unknown.sh
@@ -1,0 +1,51 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_UPSCALER}/services/i18n/__printer.sh"
+
+
+
+
+I18N_Status_Error_Input_Unknown() {
+        # execute
+        case "$UPSCALER_LANG" in
+        DE|de)
+                # German
+                I18N_Status_Print "error" "Unbekanntes/fehlendes Eingabeziel.\n"
+                ;;
+        *)
+                # fallback to default english
+                I18N_Status_Print "error" "Unknown/missing input target.\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}

--- a/init/services/i18n/error-input-unsupported.ps1
+++ b/init/services/i18n/error-input-unsupported.ps1
@@ -1,0 +1,55 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_UPSCALER}\services\i18n\__printer.ps1"
+
+
+
+
+function I18N-Status-Error-Input-Unsupported {
+	param(
+		[string]$___mime
+	)
+
+
+	# execute
+	switch (${env:UPSCALER_LANG}) {
+	{ $_ -in "DE", "de" } {
+		# german
+		$null = I18N-Status-Print "error" `
+		"Nicht unterstützter Eingabezieltyp: ${___mime}`n"
+	} default {
+		# fallback to default english
+		$null = I18N-Status-Print "error" "Unsupported input target type: ${___mime}`n"
+	}}
+
+
+	# report status
+	return 0
+}

--- a/init/services/i18n/error-input-unsupported.sh
+++ b/init/services/i18n/error-input-unsupported.sh
@@ -1,0 +1,54 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_UPSCALER}/services/i18n/__printer.sh"
+
+
+
+
+I18N_Status_Error_Input_Unsupported() {
+        #___mime="$1"
+
+
+        # execute
+        case "$UPSCALER_LANG" in
+        DE|de)
+                # German
+                I18N_Status_Print "error" "Nicht unterstützter Eingabezieltyp: ${1}\n"
+                ;;
+        *)
+                # fallback to default english
+                I18N_Status_Print "error" "Unsupported input target type: ${1}\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}

--- a/init/services/io/fs.ps1
+++ b/init/services/io/fs.ps1
@@ -175,6 +175,60 @@ function FS-Extension-Replace {
 
 
 
+function FS-Get-MIME {
+	param(
+		[string]$___target
+	)
+
+
+	# validate input
+	if ((FS-Is-Target-Exist $___target) -ne 0) {
+		return ""
+	}
+
+
+	# execute
+	$___process = FS-Is-Directory "${___target}"
+	if ($___process -eq 0) {
+		return "inode/directory"
+	}
+
+
+	switch ((Get-ChildItem $___target).Extension.ToLower()) {
+	".avif" {
+		return "image/avif"
+	} ".gif" {
+		return "image/gif"
+	} ".gzip" {
+		return "application/x-gzip"
+	} { $_ -in ".jpg", ".jpeg" } {
+		return "image/jpeg"
+	} ".json" {
+		return "application/json"
+	} ".mkv" {
+		return "video/mkv"
+	} ".mp4" {
+		return "video/mp4"
+	} ".png" {
+		return "image/png"
+	} ".rar" {
+		return "application/x-rar-compressed"
+	} ".tiff" {
+		return "image/tiff"
+	} ".webp" {
+		return "image/webp"
+	} ".xml" {
+		return "application/xml"
+	} ".zip" {
+		return "application/zip"
+	} default {
+		return ""
+	}}
+}
+
+
+
+
 function FS-Is-Directory {
 	param (
 		[string]$__target
@@ -235,13 +289,18 @@ function FS-Is-Target-Exist {
 
 
 	# perform checking
-	$__process = Test-Path -Path "${__target}" -ErrorAction SilentlyContinue
+	$__process = FS-Is-Directory "${__target}"
+	if ($__process -eq 0) {
+		return 0
+	}
+
+	$__process = FS-Is-File "${__target}"
+	if ($__process -eq 0) {
+		return 0
+	}
 
 
 	# report status
-	if ($__process) {
-		return 0
-	}
 	return 1
 }
 

--- a/init/services/io/fs.sh
+++ b/init/services/io/fs.sh
@@ -179,6 +179,32 @@ FS_Extension_Replace() {
 
 
 
+FS_Get_MIME() {
+        #__target="$1"
+
+
+        # validate input
+        if [ -z "$1" ]; then
+                return 1
+        fi
+
+
+        # execute
+        ___output="$(file --mime-type "$1")"
+        if [ $? -eq 0 ]; then
+                printf -- "%b" "${___output##* }"
+                return 0
+        fi
+
+
+        # report status
+        printf -- ""
+        return 1
+}
+
+
+
+
 FS_Is_Directory() {
         #__target="$1"
 
@@ -236,7 +262,13 @@ FS_Is_Target_Exist() {
 
 
         # perform checking
-        if [ -f "$1" ]; then
+        FS_Is_Directory "$1"
+        if [ $? -eq 0 ]; then
+                return 0
+        fi
+
+        FS_Is_File "$1"
+        if [ $? -eq 0 ]; then
                 return 0
         fi
 

--- a/tests/01_test_upscale_image_single.sh.ps1
+++ b/tests/01_test_upscale_image_single.sh.ps1
@@ -83,6 +83,7 @@ $null = I18N-Status-Print "note" "test single image upscale...`n"
 $__process = . "${env:LIBS_UPSCALER}\start.ps1" `
 		"--model" "upscayl-nmkd-4x-superscale-sd-178000-g" `
 		"--scale" "4" `
+		"--input" "${env:UPSCALER_PATH_ROOT}/tests/image/sample-01.jpeg"
 if ($__process -ne 0) {
 	$null = I18N-Status-Print "error" "Failed.`n`n"
 	$__verdict = $false
@@ -168,7 +169,8 @@ __verdict=0
 I18N_Status_Print "note" "test single image upscale...\n"
 . "${LIBS_UPSCALER}"/start.sh \
 	--model upscayl-nmkd-4x-superscale-sd-178000-g \
-	--scale 4
+	--scale 4 \
+	--input "${UPSCALER_PATH_ROOT}/tests/image/sample-01.jpeg"
 if [ $? -ne 0 ]; then
 	I18N_Status_Print "error" "Failed.\n\n"
 	__verdict=1


### PR DESCRIPTION
Since we need to make sure the input is actually a valid one, we should proceed to add its validator in. Hence, let's do this.

This patch adds input target validator into init/ directory.