### PR TITLE
init: added parallelism count support

### DIFF
--- a/init/services/i18n/error-parallel-unsupported.ps1
+++ b/init/services/i18n/error-parallel-unsupported.ps1
@@ -1,0 +1,55 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_UPSCALER}\services\i18n\__printer.ps1"
+
+
+
+
+function I18N-Status-Error-Parallelism-Unsupported {
+	param(
+		[string]$___parallel
+	)
+
+
+	# execute
+	switch (${env:UPSCALER_LANG}) {
+	{ $_ -in "DE", "de" } {
+		# german
+		$null = I18N-Status-Print "error" `
+		"Anzahl der nicht unterstützten Parallelitäten: ${___parallel}`n"
+	} default {
+		# fallback to default english
+		$null = I18N-Status-Print "error" "Unsupported parallelism count: ${___parallel}`n"
+	}}
+
+
+	# report status
+	return 0
+}

--- a/init/services/i18n/error-parallel-unsupported.sh
+++ b/init/services/i18n/error-parallel-unsupported.sh
@@ -1,0 +1,55 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_UPSCALER}/services/i18n/__printer.sh"
+
+
+
+
+I18N_Status_Error_Parallel_Unsupported() {
+        #___parallel="$1"
+
+
+        # execute
+        case "$UPSCALER_LANG" in
+        DE|de)
+                # German
+                I18N_Status_Print "error" \
+                "Anzahl der nicht unterstützten Parallelitäten: ${1}\n"
+                ;;
+        *)
+                # fallback to default english
+                I18N_Status_Print "error" "Unsupported parallelism count: ${1}\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -96,6 +96,7 @@ ${env:LIBS_UPSCALER} = "${env:UPSCALER_PATH_ROOT}\${env:UPSCALER_PATH_SCRIPTS}"
 . "${env:LIBS_UPSCALER}\services\i18n\error-input-unknown.ps1"
 . "${env:LIBS_UPSCALER}\services\i18n\error-input-unsupported.ps1"
 . "${env:LIBS_UPSCALER}\services\i18n\error-model-unknown.ps1"
+. "${env:LIBS_UPSCALER}\services\i18n\error-parallel-unsupported.ps1"
 . "${env:LIBS_UPSCALER}\services\i18n\error-scale-unknown.ps1"
 . "${env:LIBS_UPSCALER}\services\i18n\error-unsupported.ps1"
 . "${env:LIBS_UPSCALER}\services\i18n\help.ps1"
@@ -238,6 +239,18 @@ if ((STRINGS-Is-Empty "${env:UPSCALER_TEST_MODE}") -eq "0") {
 		$null = I18N-Status-Error-GPU-Unsupported "${__gpu}"
 		return 1
 	}
+}
+
+
+
+
+# process parallelism
+if ((STRINGS-Is-Empty "${__parallel}") -eq 0) {
+	$__parallel = 1
+}
+if (-not ($__parallel -match "^[\d]+$")) {
+	$null = I18N-Status-Error-Parallel-Unsupported "${__parallel}"
+	return 1
 }
 
 

--- a/init/start.sh
+++ b/init/start.sh
@@ -88,6 +88,7 @@ export LIBS_UPSCALER="${UPSCALER_PATH_ROOT}/${UPSCALER_PATH_SCRIPTS}"
 . "${LIBS_UPSCALER}/services/i18n/error-input-unknown.sh"
 . "${LIBS_UPSCALER}/services/i18n/error-input-unsupported.sh"
 . "${LIBS_UPSCALER}/services/i18n/error-model-unknown.sh"
+. "${LIBS_UPSCALER}/services/i18n/error-parallel-unsupported.sh"
 . "${LIBS_UPSCALER}/services/i18n/error-scale-unknown.sh"
 . "${LIBS_UPSCALER}/services/i18n/error-unsupported.sh"
 . "${LIBS_UPSCALER}/services/i18n/help.sh"
@@ -240,6 +241,18 @@ if [ "$(STRINGS_Is_Empty "$UPSCALER_TEST_MODE")" = "0" ]; then
                 I18N_Status_Error_GPU_Unsupported "$__gpu"
                 return 1
         fi
+fi
+
+
+
+
+# process parallelism
+__parallel="${__parallel:-1}"
+if [ "$__parallel" -eq "$__parallel" ]  2>/dev/null; then
+        :
+else
+        I18N_Status_Error_Parallel_Unsupported "$__parallel"
+        return 1
 fi
 
 

--- a/tests/01_test_upscale_image_single.sh.ps1
+++ b/tests/01_test_upscale_image_single.sh.ps1
@@ -83,6 +83,7 @@ $null = I18N-Status-Print "note" "test single image upscale...`n"
 $__process = . "${env:LIBS_UPSCALER}\start.ps1" `
 		"--model" "upscayl-nmkd-4x-superscale-sd-178000-g" `
 		"--scale" "4" `
+		"--parallel" "2" `
 		"--input" "${env:UPSCALER_PATH_ROOT}/tests/image/sample-01.jpeg"
 if ($__process -ne 0) {
 	$null = I18N-Status-Print "error" "Failed.`n`n"
@@ -170,6 +171,7 @@ I18N_Status_Print "note" "test single image upscale...\n"
 . "${LIBS_UPSCALER}"/start.sh \
 	--model upscayl-nmkd-4x-superscale-sd-178000-g \
 	--scale 4 \
+	--parallel 2 \
 	--input "${UPSCALER_PATH_ROOT}/tests/image/sample-01.jpeg"
 if [ $? -ne 0 ]; then
 	I18N_Status_Print "error" "Failed.\n\n"


### PR DESCRIPTION
Since we want to support parallel processing from the get-go, we have to supply its validator. Hence, let's do this.

This patch adds parallelism count support into init/ directory.