### PR TITLE
init: added format validator

### DIFF
--- a/init/services/compilers/upscaler.ps1
+++ b/init/services/compilers/upscaler.ps1
@@ -34,6 +34,36 @@
 
 
 
+function UPSCALER-Format-Validate {
+	param(
+		[string]$___format
+	)
+
+
+	# valdiate input
+	if ((STRINGS-Is-Empty "${___format}") -eq 0) {
+		return ""
+	}
+
+
+	# execute
+	switch ($(STRINGS-To-Lowercase "${___format}")) {
+	{ $_ -in "jpeg", "jpg" } {
+		return "jpg"
+	} "png" {
+		return "png"
+	} "webp" {
+		return "webp"
+	} "native" {
+		return "native"
+	} default {
+		return ""
+	}}
+}
+
+
+
+
 function UPSCALER-GPU-Scan {
 	# validate input
 	$___program = UPSCALER-Program-Get

--- a/init/services/compilers/upscaler.sh
+++ b/init/services/compilers/upscaler.sh
@@ -36,6 +36,45 @@
 
 
 
+UPSCALER_Format_Validate() {
+        #___format="$1"
+
+
+        # validate input
+        if [ "$(STRINGS_Is_Empty "$1")" = "0" ]; then
+                printf -- ""
+                return 1
+        fi
+
+
+        # execute
+        case "$(STRINGS_To_Lowercase "$1")" in
+        jpeg|jpg)
+                printf -- "jpg"
+                ;;
+        png)
+                printf -- "png"
+                ;;
+        webp)
+                printf -- "webp"
+                ;;
+        native)
+                printf -- "native"
+                ;;
+        *)
+                printf -- ""
+                return 1
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}
+
+
+
+
 UPSCALER_GPU_Scan() {
         # validate input
         ___program="$(UPSCALER_Program_Get)"

--- a/init/services/i18n/error-format-unsupported.ps1
+++ b/init/services/i18n/error-format-unsupported.ps1
@@ -1,0 +1,50 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_UPSCALER}\services\i18n\__printer.ps1"
+
+
+
+
+function I18N-Status-Error-Format-Unsupported {
+	# execute
+	switch (${env:UPSCALER_LANG}) {
+	{ $_ -in "DE", "de" } {
+		# german
+		$null = I18N-Status-Print "error" `
+		"Nicht unterstütztes festgelegtes Ausgabeformat.`n"
+	} default {
+		# fallback to default english
+		$null = I18N-Status-Print "error" "Unsupported designated output format.`n"
+	}}
+
+
+	# report status
+	return 0
+}

--- a/init/services/i18n/error-format-unsupported.sh
+++ b/init/services/i18n/error-format-unsupported.sh
@@ -1,0 +1,51 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_UPSCALER}/services/i18n/__printer.sh"
+
+
+
+
+I18N_Status_Error_Format_Unsupported() {
+        # execute
+        case "$UPSCALER_LANG" in
+        DE|de)
+                # German
+                I18N_Status_Print "error" "Nicht unterstütztes festgelegtes Ausgabeformat.\n"
+                ;;
+        *)
+                # fallback to default english
+                I18N_Status_Print "error" "Unsupported designated output format.\n"
+                ;;
+        esac
+
+
+        # report status
+        return 0
+}

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -92,6 +92,7 @@ ${env:LIBS_UPSCALER} = "${env:UPSCALER_PATH_ROOT}\${env:UPSCALER_PATH_SCRIPTS}"
 # import fundamental libraries
 . "${env:LIBS_UPSCALER}\services\io\strings.ps1"
 . "${env:LIBS_UPSCALER}\services\compilers\upscaler.ps1"
+. "${env:LIBS_UPSCALER}\services\i18n\error-format-unsupported.ps1"
 . "${env:LIBS_UPSCALER}\services\i18n\error-gpu-unsupported.ps1"
 . "${env:LIBS_UPSCALER}\services\i18n\error-input-unknown.ps1"
 . "${env:LIBS_UPSCALER}\services\i18n\error-input-unsupported.ps1"
@@ -250,6 +251,19 @@ if ((STRINGS-Is-Empty "${__parallel}") -eq 0) {
 }
 if (-not ($__parallel -match "^[\d]+$")) {
 	$null = I18N-Status-Error-Parallel-Unsupported "${__parallel}"
+	return 1
+}
+
+
+
+
+# process format
+if ((STRINGS-Is-Empty "${__format}") -eq 0) {
+	$__format = "native"
+}
+$__format = UPSCALER-Format-Validate "${__format}"
+if ((STRINGS-Is-Empty "${__format}") -eq 0) {
+	$null = I18N-Status-Error-Format-Unsupported
 	return 1
 }
 

--- a/init/start.sh
+++ b/init/start.sh
@@ -84,6 +84,7 @@ export LIBS_UPSCALER="${UPSCALER_PATH_ROOT}/${UPSCALER_PATH_SCRIPTS}"
 # import fundamental libraries
 . "${LIBS_UPSCALER}/services/io/strings.sh"
 . "${LIBS_UPSCALER}/services/compilers/upscaler.sh"
+. "${LIBS_UPSCALER}/services/i18n/error-format-unsupported.sh"
 . "${LIBS_UPSCALER}/services/i18n/error-gpu-unsupported.sh"
 . "${LIBS_UPSCALER}/services/i18n/error-input-unknown.sh"
 . "${LIBS_UPSCALER}/services/i18n/error-input-unsupported.sh"
@@ -252,6 +253,16 @@ if [ "$__parallel" -eq "$__parallel" ]  2>/dev/null; then
         :
 else
         I18N_Status_Error_Parallel_Unsupported "$__parallel"
+        return 1
+fi
+
+
+
+
+# process format
+__format="$(UPSCALER_Format_Validate "${__format:-native}")"
+if [ "$(STRINGS_Is_Empty "$__format")" = "0" ]; then
+        I18N_Status_Error_Format_Unsupported
         return 1
 fi
 


### PR DESCRIPTION
Since the output format is selectable, we have to add its validator function. Let's do this.

This patcha dds format validator into init/ directory.