### PR TITLE
init: fixed output path determination error

### DIFF
--- a/init/services/compilers/upscaler.ps1
+++ b/init/services/compilers/upscaler.ps1
@@ -206,7 +206,11 @@ function UPSCALER-Output-Filename-Image {
 
 	# execute
 	$___output = FS-Extension-Remove "$(Split-Path -Leaf -Path "${___input}")" "*"
-	$___output = "$(Split-Path -Parent -Path "${___input}")\${___output}-upscaled"
+	if ($(Split-Path -Parent -Path "${___input}") -ne "${___input}") {
+		$___output = "$(Split-Path -Parent -Path "${___input}")\${___output}-upscaled"
+	} else {
+		$___output = ".\${___output}-upscaled"
+	}
 
 	switch ($___format) {
 	"jpg" {

--- a/init/services/compilers/upscaler.sh
+++ b/init/services/compilers/upscaler.sh
@@ -213,7 +213,11 @@ UPSCALER_Output_Filename_Image() {
 
         # execute
         ___output="$(FS_Extension_Remove "${2##*/}" "*")"
-        ___output="${2%/*}/${___output}-upscaled"
+        if [ ! "${2%/*}" = "$2" ]; then
+                ___output="${2%/*}/${___output}-upscaled"
+        else
+                ___output="./${___output}-upscaled"
+        fi
 
         case "$3" in
         jpg)


### PR DESCRIPTION
There was an error determining the output path where if the given path is only a filepath (without directory), the program will try to use the original input filename as a directory and cause the upscaling process to be unreasonably failed. Hence, we need to fix this bug.

This patch fixes the output path determination error in init/ directory.