### PR TITLE
unix.sh - fix mkdir issue

### DIFF
--- a/init/unix.sh
+++ b/init/unix.sh
@@ -311,6 +311,10 @@ _check_io() {
         subject_ext="${subject_name#*.}"
         subject_name="${subject_name%%.*}"
 
+        if [ "${subject_dir}" = "${input}" ]; then
+                subject_dir="${subject_name}"
+        fi
+
         if [ $video_mode -gt 0 ]; then
                 if [ "$(type -p ffmpeg)" = "" ]; then
                         _print_status error "missing required ffmpeg program for video.\n"


### PR DESCRIPTION
fix issue when creating directory where input file of a video is in the same directory to output and has relative path.

Given:
/usr/bin/upscaler --model upscayl-ultrasharp \
        --scale 2 \
        --format png \
        --video \
        --input my-video.mp4 \
        --output my-video-upscaled

The program tries to create a directory ./my-video.mp4/something/something throws an error and stop the execution

This fix uses "my-video" instead of "my-video.mp4" as subject dir if subject_dir is equal to input.