### PR TITLE
init: ported HestiaOS library

### DIFF
--- a/init/services/HestiaOS/Exec.ps1
+++ b/init/services/HestiaOS/Exec.ps1
@@ -1,0 +1,125 @@
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\hestiaKERNEL\Error_Codes.ps1"
+
+
+
+
+function HestiaOS-Exec {
+        param (
+                [string]$___command,
+                [string]$___arguments,
+                [string]$___log_stdout,
+                [string]$___log_stderr
+        )
+
+
+        # validate input
+        if (Test-Path -Path $___command -ErrorAction SilentlyContinue) {
+                $___program = $___command
+        } else {
+                $___program = Get-Command $___command -ErrorAction SilentlyContinue
+                if (-not ($___program)) {
+                        return ${env:hestiaKERNEL_ERROR_DATA_EMPTY}
+                }
+        }
+
+
+        # execute command
+        if ($___arguments -eq "") {
+                if (
+                        ($___log_stdout -ne "") -and ($___log_stderr -ne "")
+                ) {
+                        $___process = Start-Process -Wait `
+                                                -FilePath $___program `
+                                                -NoNewWindow `
+                                                -PassThru `
+                                                -RedirectStandardOutput $___log_stdout `
+                                                -RedirectStandardError $___log_stderr
+                } elseif ($___log_stdout -ne "") {
+                        $___process = Start-Process -Wait `
+                                                -FilePath $___program `
+                                                -NoNewWindow `
+                                                -PassThru `
+                                                -RedirectStandardOutput $___log_stdout
+                } elseif ($___log_stderr -ne "") {
+                        $___process = Start-Process -Wait `
+                                                -FilePath $___program `
+                                                -NoNewWindow `
+                                                -PassThru `
+                                                -RedirectStandardError $___log_stderr
+                } else {
+                        $___process = Start-Process -Wait `
+                                                -FilePath $___program `
+                                                -NoNewWindow `
+                                                -PassThru
+                }
+        } else {
+                if (
+                        ($___log_stdout -ne "") -and ($___log_stderr -ne "")
+                ) {
+                        $___process = Start-Process -Wait `
+                                                -FilePath $___program `
+                                                -NoNewWindow `
+                                                -PassThru `
+                                                -ArgumentList $___arguments `
+                                                -RedirectStandardOutput $___log_stdout `
+                                                -RedirectStandardError $___log_stderr
+                } elseif ($___log_stdout -ne "") {
+                        $___process = Start-Process -Wait `
+                                                -FilePath $___program `
+                                                -NoNewWindow `
+                                                -PassThru `
+                                                -ArgumentList $___arguments `
+                                                -RedirectStandardOutput $___log_stdout
+                } elseif ($___log_stderr -ne "") {
+                        $___process = Start-Process -Wait `
+                                                -FilePath $___program `
+                                                -NoNewWindow `
+                                                -PassThru `
+                                                -ArgumentList $___arguments `
+                                                -RedirectStandardError $___log_stderr
+                } else {
+                        $___process = Start-Process -Wait `
+                                                -FilePath $___program `
+                                                -NoNewWindow `
+                                                -PassThru `
+                                                -ArgumentList $___arguments
+                }
+        }
+
+        if ($___process.ExitCode -ne 0) {
+                return ${env:hestiaKERNEL_ERROR_BAD_EXEC}
+        }
+
+
+        # report status
+        return ${env:hestiaKERNEL_ERROR_OK}
+}

--- a/init/services/HestiaOS/Exec.sh
+++ b/init/services/HestiaOS/Exec.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/hestiaKERNEL/Error_Codes.sh"
+
+
+
+
+HestiaOS_Exec() {
+        #___command="$1"
+        #___argument="$2"
+        #___log_stdout="$3"
+        #___log_stderr="$4"
+
+
+        # validate input
+        if [ "$1" = "" ]; then
+                return $HestiaKERNEL_ERROR_DATA_EMPTY
+        fi
+
+
+        # execute command
+        if [ ! "$3" = "" ] || [ ! "$4" = "" ]; then
+                "$1" $2 1>"$3" 2>"$4"
+        elif [ ! "$3" = "" ]; then
+                "$1" $2 1>"$3"
+        elif [ ! "$4" = "" ]; then
+                "$1" $2 2>"$4"
+        else
+                "$1" $2
+        fi
+
+        if [ $? -ne 0 ]; then
+                return $HestiaKERNEL_ERROR_BAD_EXEC
+        fi
+
+
+        # report status
+        return $HestiaKERNEL_ERROR_OK
+}
+################################################################################
+# Unix Main Codes                                                              #
+################################################################################
+return 0
+#>

--- a/init/services/HestiaOS/Get_Arch.ps1
+++ b/init/services/HestiaOS/Get_Arch.ps1
@@ -1,0 +1,38 @@
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\HestiaOS\To_Arch.ps1"
+
+
+
+
+function HestiaOS-Get-Arch {
+        # execute
+        return HestiaOS-To-Arch "$((Get-ComputerInfo).CsProcessors.Architecture)"
+}

--- a/init/services/HestiaOS/Get_Arch.sh
+++ b/init/services/HestiaOS/Get_Arch.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/HestiaOS/To_Arch.sh"
+
+
+
+
+HestiaOS_Get_Arch() {
+        # execute
+        printf -- "%b" "$(HestiaOS_To_Arch "$(uname -m)")"
+}

--- a/init/services/HestiaOS/Is_Command_Available.ps1
+++ b/init/services/HestiaOS/Is_Command_Available.ps1
@@ -1,0 +1,56 @@
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Error_Codes.ps1"
+
+
+
+
+function HestiaOS-Is-Command-Available {
+        param (
+                [string]$___command
+        )
+
+
+        # validate input
+        if ($___command -eq "") {
+                return ${env:HestiaKERNEL_ERROR_DATA_MISSING}
+        }
+
+
+        # execute
+        $___process = Get-Command $___command -ErrorAction SilentlyContinue
+        if ($___process) {
+                return ${env:HestiaKERNEL_ERROR_OK}
+        }
+
+
+        # report status
+        return ${env:HestiaKERNEL_ERROR_DATA_MISSING}
+}

--- a/init/services/HestiaOS/Is_Command_Available.sh
+++ b/init/services/HestiaOS/Is_Command_Available.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+
+
+
+
+HestiaOS_Is_Command_Available() {
+        #___command="$1"
+
+
+        # validate input
+        if [ "$1" = "" ]; then
+                printf -- "%d" $HestiaKERNEL_ERROR_DATA_MISSING
+                return $HestiaKERNEL_ERROR_DATA_MISSING
+        fi
+
+
+        # execute
+        ___ret="$(type "$1")"
+        if [ "${___ret##*not found}" = "$___ret" ]; then
+                printf -- "%d" $HestiaKERNEL_ERROR_OK
+                return $HestiaKERNEL_ERROR_OK
+        fi
+
+
+        # report status
+        printf -- "%d" $HestiaKERNEL_ERROR_DATA_MISSING
+        return $HestiaKERNEL_ERROR_DATA_MISSING
+}

--- a/init/services/HestiaOS/Is_Simulation_Mode.ps1
+++ b/init/services/HestiaOS/Is_Simulation_Mode.ps1
@@ -1,0 +1,49 @@
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Error_Codes.ps1"
+
+
+
+
+function HestiaOS-Is-Simulation-Mode {
+        param (
+                [string]$___environment_variable
+        )
+
+
+        # execute
+        if ($___environment_variable -ne "") {
+                return ${env:HestiaKERNEL_ERROR_OK}
+        }
+
+
+        # report status
+        return ${env:HestiaKERNEL_ERROR_DATA_MISSING}
+}

--- a/init/services/HestiaOS/Is_Simulation_Mode.sh
+++ b/init/services/HestiaOS/Is_Simulation_Mode.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+
+
+
+
+HestiaOS_Is_Simulation_Mode() {
+        #___environment_variable="$1"
+
+
+        # execute
+        if [ ! "$1" = "" ]; then
+                printf -- "%d" $HestiaKERNEL_ERROR_OK
+                return $HestiaKERNEL_ERROR_OK
+        fi
+
+
+        # report status
+        printf -- "%d" $HestiaKERNEL_ERROR_DATA_MISSING
+        return $HestiaKERNEL_ERROR_DATA_MISSING
+}

--- a/init/services/HestiaOS/Is_Variable_Set.ps1
+++ b/init/services/HestiaOS/Is_Variable_Set.ps1
@@ -1,0 +1,56 @@
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Error_Codes.ps1"
+
+
+
+
+function HestiaOS-Is-Variable-Exist {
+        param (
+                [string]$___name,
+                [string]$___scope
+        )
+
+
+        # validate input
+        if ($___name -eq "") {
+                return ${env:HestiaKERNEL_ERROR_DATA_MISSING}
+        }
+
+
+        # execute
+        if (Get-Variable $___name -Scope $___scope -ErrorAction 'Ignore') {
+                return ${env:HestiaKERNEL_ERROR_OK}
+        }
+
+
+        # report status
+        return ${env:HestiaKERNEL_ERROR_DATA_MISSING}
+}

--- a/init/services/HestiaOS/Is_Variable_Set.sh
+++ b/init/services/HestiaOS/Is_Variable_Set.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+
+
+
+
+HestiaOS_Is_Variable_Exist() {
+        #___name="$1"
+        #___scope="$2"
+
+
+        # validate input
+        if [ "$1" = "" ]; then
+                printf -- "%d" $HestiaKERNEL_ERROR_DATA_MISSING
+                return $HestiaKERNEL_ERROR_DATA_MISSING
+        fi
+
+
+        # execute
+        # NOTICE
+        # POSIX Shell is always scoped globally. To ensure the algorithm is
+        # inter-translatable, the scope parameter is maintained but unused.
+        if [ ! "$(eval "printf -- \"%s\" \"\${$1}\"")" = "" ]; then
+                printf -- "%d" $HestiaKERNEL_ERROR_OK
+                return $HestiaKERNEL_ERROR_OK
+        fi
+
+
+        # report status
+        printf -- "%d" $HestiaKERNEL_ERROR_DATA_MISSING
+        return $HestiaKERNEL_ERROR_DATA_MISSING
+}

--- a/init/services/HestiaOS/To_Arch.ps1
+++ b/init/services/HestiaOS/To_Arch.ps1
@@ -1,0 +1,53 @@
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+function HestiaOS-To-Arch {
+        param (
+                [string]$___value
+        )
+
+
+        # execute
+        switch ($___value.ToLower()) {
+        { $_ -in "i686-64", "ia64" } {
+                return "ia64"
+        } { $_ -in "386", "i386", "486", "i486", "586", "i586", "686", "i686", "x86" } {
+                return "i386"
+        } { $_ -match "ip*" } {
+                return "mips"
+        } { $_ -in "x86_64", "x64" } {
+                return "amd64"
+        } "sun4u" {
+                return "sparc"
+        } { $_ -in "power macintosh" } {
+                return "powerpc"
+        } default {
+                return $___value.ToLower()
+        }}
+}

--- a/init/services/HestiaOS/To_Arch.sh
+++ b/init/services/HestiaOS/To_Arch.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+HestiaOS_To_Arch() {
+        #___value="$1"
+
+
+        # execute
+        case "$(printf -- "%b" "$1" | tr '[:upper:]' '[:lower:]')" in
+        i686-64|ia64)
+                printf -- "%s" "ia64"
+                ;;
+        386|i386|486|i486|586|i586|686|i686|x86)
+                printf -- "%s" "i386"
+                ;;
+        x86_64|x64)
+                printf -- "%s" "amd64"
+                ;;
+        sun4u)
+                printf -- "%s" "sparc"
+                ;;
+        "power macintosh")
+                printf -- "%s" "powerpc"
+                ;;
+        ip*)
+                printf -- "%s" "mips"
+                ;;
+        *)
+                printf -- "%s" "$1" | tr '[:upper:]' '[:lower:]'
+                ;;
+        esac
+        return 0
+}

--- a/init/services/HestiaOS/To_Arch_MSFT.ps1
+++ b/init/services/HestiaOS/To_Arch_MSFT.ps1
@@ -1,0 +1,57 @@
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+function HestiaOS-To-Arch-MSFT {
+        param (
+                [string]$___value
+        )
+
+
+        # execute
+        switch ($___value) {
+        "alpha" {
+                return "Alpha"
+        } "arm" {
+                return "ARM"
+        } "arm64" {
+                return "ARM64"
+        } "ia64" {
+                return "ia64"
+        } "i386" {
+                return "x86"
+        } "mips" {
+                return "MIPs"
+        } "amd64" {
+                return "x64"
+        } "powerpc" {
+                return "PowerPC"
+        } default {
+                return ""
+        }}
+}

--- a/init/services/HestiaOS/To_Arch_MSFT.sh
+++ b/init/services/HestiaOS/To_Arch_MSFT.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+HestiaOS_To_Arch_MSFT() {
+        #___value="$1"
+
+
+        # execute
+        case "$(printf -- "%b" "$1" | tr '[:upper:]' '[:lower:]')" in
+        alpha)
+                printf -- "%s" "Alpha"
+                ;;
+        arm)
+                printf -- "%s" "ARM"
+                ;;
+        arm64)
+                printf -- "%s" "ARM64"
+                ;;
+        ia64)
+                printf -- "%s" "ia64"
+                ;;
+        i386)
+                printf -- "%s" "x86"
+                ;;
+        mips)
+                printf -- "%s" "MIPs"
+                ;;
+        amd64)
+                printf -- "%s" "x64"
+                ;;
+        powerpc)
+                printf -- "%s" "PowerPC"
+                ;;
+        *)
+                printf -- ""
+                ;;
+        esac
+}

--- a/init/services/HestiaOS/To_Arch_UNIX.ps1
+++ b/init/services/HestiaOS/To_Arch_UNIX.ps1
@@ -1,0 +1,63 @@
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+function HestiaOS-To-Arch-UNIX {
+        param (
+                [string]$___value
+        )
+
+
+        # execute
+        switch ($___value.ToLower()) {
+        { $_ -in "any", "none" } {
+                return "all"
+        } { $_ -in "386", "i386", "486", "i486", "586", "i586", "686", "i686" } {
+                return "i386"
+        } "armle" {
+                return "armel"
+        } "mipsle" {
+                return "mipsel"
+        } "mipsr6le" {
+                return "mipsr6el"
+        } "mipsn32le" {
+                return "mipsn32el"
+        } "mipsn32r6le" {
+                return "mipsn32r6el"
+        } "mips64le" {
+                return "mips64el"
+        } "mips64r6le" {
+                return "mips64r6el"
+        } "powerpcle" {
+                return "powerpcel"
+        } "ppc64le" {
+                return "ppc64el"
+        } default {
+                return $___value.ToLower()
+        }}
+}

--- a/init/services/HestiaOS/To_Arch_UNIX.sh
+++ b/init/services/HestiaOS/To_Arch_UNIX.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+HestiaOS_To_Arch_UNIX() {
+        #___value="$1"
+
+
+        # execute
+        case "$(printf -- "%b" "$1" | tr '[:upper:]' '[:lower:]')" in
+        any|none)
+                printf -- "%s" "all"
+                ;;
+        386|i386|486|i486|586|i586|686|i686)
+                printf -- "%s" "i386"
+                ;;
+        armle)
+                printf -- "%s" "armel"
+                ;;
+        mipsle)
+                printf -- "%s" "mipsel"
+                ;;
+        mipsr6le)
+                printf -- "%s" "mipsr6el"
+                ;;
+        mipsn32le)
+                printf -- "%s" "mipsn32el"
+                ;;
+        mipsn32r6le)
+                printf -- "%s" "mipsn32r6el"
+                ;;
+        mips64le)
+                printf -- "%s" "mips64el"
+                ;;
+        mips64r6le)
+                printf -- "%s" "mips64r6el"
+                ;;
+        powerpcle)
+                printf -- "%s" "powerpcel"
+                ;;
+        ppc64le)
+                printf -- "%s" "ppc64el"
+                ;;
+        *)
+                printf -- "%b" "$1" | tr '[:upper:]' '[:lower:]'
+                ;;
+        esac
+        return 0
+}

--- a/init/services/HestiaOS/To_OS.ps1
+++ b/init/services/HestiaOS/To_OS.ps1
@@ -1,0 +1,51 @@
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+function HestiaOS-To-OS {
+        param (
+                [string]$___value
+        )
+
+
+        # execute
+        switch -Wildcard ($___value.ToLower()) {
+        { $_ -in "windows*", "ms-dos*" } {
+                return "windows"
+        } { $_ -in "cygwin*", "mingw*", "mingw32*", "msys*" } {
+                return "windows"
+        } { $_ -match "*freebsd" } {
+                return "freebsd"
+        } "dragonfly" {
+                return "dragonfly"
+        } { $_ -in "standalone", "unknown", "none" } {
+                return "none"
+        } default {
+                return $___value.ToLower()
+        }}
+}

--- a/init/services/HestiaOS/To_OS.sh
+++ b/init/services/HestiaOS/To_OS.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Copyright (c) 2024, (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+HestiaOS_To_OS() {
+        #___value="$1"
+
+
+        # execute
+        case "$(printf -- "%b" "$1" | tr '[:upper:]' '[:lower:]')" in
+        windows*|ms-dos*)
+                printf -- "%s" "windows"
+                ;;
+        cygwin*|mingw*|mingw32*|msys*)
+                printf -- "%s" "windows"
+                ;;
+        *freebsd)
+                printf -- "%s" "freebsd"
+                ;;
+        dragonfly*)
+                printf -- "%s" "dragonfly"
+                ;;
+        standalone|unknown|none)
+                printf -- "%s" "none"
+                ;;
+        *)
+                printf -- "%s" "$1" | tr '[:upper:]' '[:lower:]'
+                ;;
+        esac
+        return 0
+}

--- a/init/services/HestiaOS/Vanilla.sh.ps1
+++ b/init/services/HestiaOS/Vanilla.sh.ps1
@@ -1,0 +1,68 @@
+echo \" <<'RUN_AS_BATCH' >/dev/null ">NUL "\" \`" <#"
+@ECHO OFF
+REM LICENSE CLAUSES HERE
+REM ----------------------------------------------------------------------------
+
+
+
+
+REM ############################################################################
+REM # Windows BATCH Codes                                                      #
+REM ############################################################################
+where /q powershell
+if errorlevel 1 (
+        echo "ERROR: missing powershell facility."
+        exit /b 1
+)
+
+copy /Y "%~nx0" "%~n0.ps1" >nul
+timeout /t 1 /nobreak >nul
+powershell -executionpolicy remotesigned -Command "& '.\%~n0.ps1' %*"
+start /b "" cmd /c del "%~f0" & exit /b %errorcode%
+REM ############################################################################
+REM # Windows BATCH Codes                                                      #
+REM ############################################################################
+RUN_AS_BATCH
+#> | Out-Null
+
+
+
+
+echo \" <<'RUN_AS_POWERSHELL' >/dev/null # " | Out-Null
+################################################################################
+# Windows POWERSHELL Codes                                                     #
+################################################################################
+. "${env:LIBS_HESTIA}\HestiaOS\Exec.ps1"
+. "${env:LIBS_HESTIA}\HestiaOS\Get_Arch.ps1"
+. "${env:LIBS_HESTIA}\HestiaOS\Is_Command_Available.ps1"
+. "${env:LIBS_HESTIA}\HestiaOS\Is_Simulation_Mode.ps1"
+. "${env:LIBS_HESTIA}\HestiaOS\To_Arch.ps1"
+. "${env:LIBS_HESTIA}\HestiaOS\To_Arch_MSFT.ps1"
+. "${env:LIBS_HESTIA}\HestiaOS\To_Arch_UNIX.ps1"
+. "${env:LIBS_HESTIA}\HestiaOS\To_OS.ps1"
+################################################################################
+# Windows POWERSHELL Codes                                                     #
+################################################################################
+return
+<#
+RUN_AS_POWERSHELL
+
+
+
+
+################################################################################
+# Unix Main Codes                                                              #
+################################################################################
+. "${LIBS_HESTIA}/HestiaOS/Exec.sh"
+. "${LIBS_HESTIA}/HestiaOS/Get_Arch.sh"
+. "${LIBS_HESTIA}/HestiaOS/Is_Command_Available.sh"
+. "${LIBS_HESTIA}/HestiaOS/Is_Simulation_Mode.sh"
+. "${LIBS_HESTIA}/HestiaOS/To_Arch.sh"
+. "${LIBS_HESTIA}/HestiaOS/To_Arch_MSFT.sh"
+. "${LIBS_HESTIA}/HestiaOS/To_Arch_UNIX.sh"
+. "${LIBS_HESTIA}/HestiaOS/To_OS.sh"
+################################################################################
+# Unix Main Codes                                                              #
+################################################################################
+return 0
+#>


### PR DESCRIPTION
Since the latest implementations are using Hestia library, it's better to port them. Let's deal with HestiaOS library.

This patch ports HestiaOS library in init/ directory.