### PR TITLE
init: exported To_UTF16_From_Unicode primitive function

### DIFF
--- a/init/services/HestiaKERNEL/Vanilla.sh.ps1
+++ b/init/services/HestiaKERNEL/Vanilla.sh.ps1
@@ -37,6 +37,7 @@ echo \" <<'RUN_AS_POWERSHELL' >/dev/null # " | Out-Null
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Run_Parallel_Sentinel.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_Unicode_From_String.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF8_From_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF16_From_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF32_From_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode.ps1"
 ################################################################################
@@ -57,6 +58,7 @@ RUN_AS_POWERSHELL
 . "${LIBS_HESTIA}/HestiaKERNEL/Run_Parallel_Sentinel.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_Unicode_From_String.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_UTF8_From_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/To_UTF16_From_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_UTF32_From_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode.sh"
 ################################################################################


### PR DESCRIPTION
It appears it was a miss during the last porting. Hence, let's export that function.

This patch exports To_UTF16_From_Unicode primitive function in init/ directory.