### PR TITLE
init: ported Get_String_Encoder primitive function

### DIFF
--- a/init/services/HestiaKERNEL/Get_String_Encoder.ps1
+++ b/init/services/HestiaKERNEL/Get_String_Encoder.ps1
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Copyright (c) 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
 #
 #
@@ -28,26 +27,21 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode.ps1"
 
 
 
 
-# Data type
-# IMPORTANT NOTICE: POSIX Shell does not have class or type declarations so we
-#                   will have to be smart about it.
-
-
-
-
-# UTF encoding type
-HestiaKERNEL_UTF8=0             # default
-HestiaKERNEL_UTF8_BOM=1
-HestiaKERNEL_UTF16BE=2          # default
-HestiaKERNEL_UTF16BE_BOM=3
-HestiaKERNEL_UTF16LE=4
-HestiaKERNEL_UTF16LE_BOM=5
-HestiaKERNEL_UTF32BE=6          # default
-HestiaKERNEL_UTF32BE_BOM=7
-HestiaKERNEL_UTF32LE=8
-HestiaKERNEL_UTF32LE_BOM=9
-HestiaKERNEL_UTF_UNKNOWN=255
+function HestiaKERNEL-Get-String-Encoder {
+        # execute
+        switch ($OutputEncoding.BodyName.ToUpper()) {
+        "UTF-8" {
+                return ${env:HestiaKERNEL_UTF8}
+        } "UTF-16" {
+                return ${env:HestiaKERNEL_UTF16BE}
+        } "UTF-32" {
+                return ${env:HestiaKERNEL_UTF32BE}
+        } "default" {
+                return ${env:HestiaKERNEL_UTF_UNKNOWN}
+        }}
+}

--- a/init/services/HestiaKERNEL/Get_String_Encoder.sh
+++ b/init/services/HestiaKERNEL/Get_String_Encoder.sh
@@ -28,26 +28,26 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode.sh"
 
 
 
 
-# Data type
-# IMPORTANT NOTICE: POSIX Shell does not have class or type declarations so we
-#                   will have to be smart about it.
-
-
-
-
-# UTF encoding type
-HestiaKERNEL_UTF8=0             # default
-HestiaKERNEL_UTF8_BOM=1
-HestiaKERNEL_UTF16BE=2          # default
-HestiaKERNEL_UTF16BE_BOM=3
-HestiaKERNEL_UTF16LE=4
-HestiaKERNEL_UTF16LE_BOM=5
-HestiaKERNEL_UTF32BE=6          # default
-HestiaKERNEL_UTF32BE_BOM=7
-HestiaKERNEL_UTF32LE=8
-HestiaKERNEL_UTF32LE_BOM=9
-HestiaKERNEL_UTF_UNKNOWN=255
+HestiaKERNEL_Get_String_Encoder() {
+        # execute
+        case "${LANG##*.}" in
+        "UTF-8")
+                printf -- "%b" "$HestiaKERNEL_UTF8"
+                ;;
+        "UTF-16")
+                printf -- "%b" "$HestiaKERNEL_UTF16BE"
+                ;;
+        "UTF-32")
+                printf -- "%b" "$HestiaKERNEL_UTF32BE"
+                ;;
+        *)
+                printf -- "%b" "$HestiaKERNEL_UTF_UNKNOWN"
+                ;;
+        esac
+        return 0
+}

--- a/init/services/HestiaKERNEL/Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode.ps1
@@ -45,13 +45,14 @@
 
 
 # UTF encoding type
-${env:HestiaKERNEL_UTF8} = 0
+${env:HestiaKERNEL_UTF8} = 0            # default
 ${env:HestiaKERNEL_UTF8_BOM} = 1
-${env:HestiaKERNEL_UTF16BE} = 2
+${env:HestiaKERNEL_UTF16BE} = 2         # default
 ${env:HestiaKERNEL_UTF16BE_BOM} = 3
 ${env:HestiaKERNEL_UTF16LE} = 4
 ${env:HestiaKERNEL_UTF16LE_BOM} = 5
-${env:HestiaKERNEL_UTF32BE} = 6
+${env:HestiaKERNEL_UTF32BE} = 6         # default
 ${env:HestiaKERNEL_UTF32BE_BOM} = 7
 ${env:HestiaKERNEL_UTF32LE} = 8
 ${env:HestiaKERNEL_UTF32LE_BOM} = 9
+${env:HestiaKERNEL_UTF_UNKNOWN} = 255

--- a/init/services/HestiaKERNEL/Vanilla.sh.ps1
+++ b/init/services/HestiaKERNEL/Vanilla.sh.ps1
@@ -33,6 +33,7 @@ echo \" <<'RUN_AS_POWERSHELL' >/dev/null # " | Out-Null
 # Windows POWERSHELL Codes                                                     #
 ################################################################################
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Error_Codes.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Get_String_Encoder.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Is_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Run_Parallel_Sentinel.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_Unicode_From_String.ps1"
@@ -54,6 +55,7 @@ RUN_AS_POWERSHELL
 # Unix Main Codes                                                              #
 ################################################################################
 . "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Get_String_Encoder.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Is_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Run_Parallel_Sentinel.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_Unicode_From_String.sh"


### PR DESCRIPTION
Since level-2 libraries use certain string functions, we have to port their primitive functions into HestiaKERNEL. Hence, let's do this.

This patch ports Get_String_Encoder primitive function into init/ directory.