### PR TITLE
init: ported To_String_From_Unicode primitive function

### DIFF
--- a/init/services/HestiaKERNEL/Endian.ps1
+++ b/init/services/HestiaKERNEL/Endian.ps1
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Copyright (c) 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
 #
 #
@@ -32,29 +31,6 @@
 
 
 
-# Data type
-# IMPORTANT NOTICE: POSIX Shell does not have class or type declarations so we
-#                   will have to be smart about it.
-
-
-
-
-# BOM type
-HestiaKERNEL_UTF_NO_BOM=0       # default
-HestiaKERNEL_UTF_BOM=1
-
-
-
-
-# UTF encoding type
-HestiaKERNEL_UTF8=0             # default
-HestiaKERNEL_UTF8_BOM=1
-HestiaKERNEL_UTF16BE=2          # default
-HestiaKERNEL_UTF16BE_BOM=3
-HestiaKERNEL_UTF16LE=4
-HestiaKERNEL_UTF16LE_BOM=5
-HestiaKERNEL_UTF32BE=6          # default
-HestiaKERNEL_UTF32BE_BOM=7
-HestiaKERNEL_UTF32LE=8
-HestiaKERNEL_UTF32LE_BOM=9
-HestiaKERNEL_UTF_UNKNOWN=255
+# endian type
+${env:HestiaKERNEL_ENDIAN_BIG} = 0              # default
+${env:HestiaKERNEL_ENDIAN_LITTLE} = 1

--- a/init/services/HestiaKERNEL/Endian.sh
+++ b/init/services/HestiaKERNEL/Endian.sh
@@ -32,29 +32,6 @@
 
 
 
-# Data type
-# IMPORTANT NOTICE: POSIX Shell does not have class or type declarations so we
-#                   will have to be smart about it.
-
-
-
-
-# BOM type
-HestiaKERNEL_UTF_NO_BOM=0       # default
-HestiaKERNEL_UTF_BOM=1
-
-
-
-
-# UTF encoding type
-HestiaKERNEL_UTF8=0             # default
-HestiaKERNEL_UTF8_BOM=1
-HestiaKERNEL_UTF16BE=2          # default
-HestiaKERNEL_UTF16BE_BOM=3
-HestiaKERNEL_UTF16LE=4
-HestiaKERNEL_UTF16LE_BOM=5
-HestiaKERNEL_UTF32BE=6          # default
-HestiaKERNEL_UTF32BE_BOM=7
-HestiaKERNEL_UTF32LE=8
-HestiaKERNEL_UTF32LE_BOM=9
-HestiaKERNEL_UTF_UNKNOWN=255
+# endian type
+HestiaKERNEL_ENDIAN_BIG=0               # default
+HestiaKERNEL_ENDIAN_LITTLE=1

--- a/init/services/HestiaKERNEL/To_String_From_Unicode.ps1
+++ b/init/services/HestiaKERNEL/To_String_From_Unicode.ps1
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Copyright (c) 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
 #
 #
@@ -28,33 +27,46 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Get_String_Encoder.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF8_From_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF16_From_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF32_From_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode.ps1"
 
 
 
 
-# Data type
-# IMPORTANT NOTICE: POSIX Shell does not have class or type declarations so we
-#                   will have to be smart about it.
+function HestiaKERNEL-To-String-From-Unicode {
+        param (
+                [uint32[]]$___unicode
+        )
 
 
+        # validate input
+        if ($___unicode.Length -eq 0) {
+                return ""
+        }
 
 
-# BOM type
-HestiaKERNEL_UTF_NO_BOM=0       # default
-HestiaKERNEL_UTF_BOM=1
+        # execute
+        # process HestiaKERNEL.Unicode data type as the last resort
+        switch (HestiaKERNEL-Get-String-Encoder) {
+        ${env:HestiaKERNEL_UTF8} {
+                $___utf = HestiaKERNEL-To-UTF8-From-Unicode $___unicode
+        } ${env:HestiaKERNEL_UTF16BE} {
+                $___utf = HestiaKERNEL-To-UTF16-From-Unicode $___unicode
+        } ${env:HestiaKERNEL_UTF32BE} {
+                $___utf = HestiaKERNEL-To-UTF32-From-Unicode $___unicode
+        } default {
+                return ""
+        }
+
+        $___converted = ""
+        foreach ($___byte in $___utf) {
+                $___converted = "${___converted}$([string][char]$___byte)"
+        }
 
 
-
-
-# UTF encoding type
-HestiaKERNEL_UTF8=0             # default
-HestiaKERNEL_UTF8_BOM=1
-HestiaKERNEL_UTF16BE=2          # default
-HestiaKERNEL_UTF16BE_BOM=3
-HestiaKERNEL_UTF16LE=4
-HestiaKERNEL_UTF16LE_BOM=5
-HestiaKERNEL_UTF32BE=6          # default
-HestiaKERNEL_UTF32BE_BOM=7
-HestiaKERNEL_UTF32LE=8
-HestiaKERNEL_UTF32LE_BOM=9
-HestiaKERNEL_UTF_UNKNOWN=255
+        # report status
+        return $___converted
+}

--- a/init/services/HestiaKERNEL/To_String_From_Unicode.sh
+++ b/init/services/HestiaKERNEL/To_String_From_Unicode.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Copyright (c) 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Get_String_Encoder.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/To_UTF8_From_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/To_UTF16_From_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/To_UTF32_From_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode.sh"
+
+
+
+
+HestiaKERNEL_To_String_From_Unicode() {
+        #___unicode="$1"
+
+
+        # validate input
+        if [ "$1" = "" ]; then
+                printf -- ""
+                return $HestiaKERNEL_ERROR_DATA_EMPTY
+        fi
+
+
+        # execute
+        # process HestiaKERNEL.Unicode data type
+        ___utf=""
+        case "$(HestiaKERNEL_Get_String_Encoder)" in
+        "$HestiaKERNEL_UTF8")
+                ___utf="$(HestiaKERNEL_To_UTF8_From_Unicode "$1")"
+                ;;
+        "$HestiaKERNEL_UTF16BE")
+                ___utf="$(HestiaKERNEL_To_UTF16_From_Unicode "$1")"
+                ;;
+        "$HestiaKERNEL_UTF32BE")
+                ___utf="$(HestiaKERNEL_To_UTF32_From_Unicode "$1")"
+                ;;
+        *)
+                printf -- ""
+                return $HestiaKERNEL_ERROR_NOT_POSSIBLE
+                ;;
+        esac
+
+        if [ "$___utf" = "" ]; then
+                printf -- ""
+                return $HestiaKERNEL_ERROR_DATA_INVALID
+        fi
+
+
+        ___converted=""
+        while [ ! "$___utf" = "" ]; do
+                ___byte="${___utf%%, *}"
+                ___converted="${___converted}$(printf -- '\%o' "$___byte")"
+                ___utf="${___utf#"$___byte"}"
+                if [ "${___utf%"${___utf#?}"}" = "," ]; then
+                        ___utf="${___utf#, }"
+                fi
+        done
+
+
+        # report status
+        printf -- "%b" "$___converted"
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/services/HestiaKERNEL/To_UTF16_From_Unicode.ps1
+++ b/init/services/HestiaKERNEL/To_UTF16_From_Unicode.ps1
@@ -27,6 +27,12 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Endian.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode.ps1"
+
+
+
+
 function HestiaKERNEL-To-UTF16-From-Unicode {
         param (
                 [uint32[]]$___content,
@@ -36,16 +42,16 @@ function HestiaKERNEL-To-UTF16-From-Unicode {
 
 
         # validate input
-        if ($___content) {
+        if ($___content.Length -eq 0) {
                 return [uint8[]]@()
         }
 
 
         # execute
         [System.Collections.Generic.List[uint8]]$___converted = @()
-        if ($___bom -ne "") {
+        if ($___bom -eq ${env:HestiaKERNEL_UTF_BOM}) {
                 switch ($___endian) {
-                { $_ -in "le", "LE", "little", "Little", "LITTLE" } {
+                ${env:HestiaKERNEL_ENDIAN_LITTLE} {
                         # UTF16LE BOM - 0xFF, 0xFE
                         $null = $___converted.Add(0xFF)
                         $null = $___converted.Add(0xFE)
@@ -63,7 +69,7 @@ function HestiaKERNEL-To-UTF16-From-Unicode {
                 if ($___char -lt 0x10000) {
                         # char < 0x10000
                         switch ($___endian) {
-                        { $_ -in "le", "LE", "little", "Little", "LITTLE" } {
+                        ${env:HestiaKERNEL_ENDIAN_LITTLE} {
                                 $___register = $___char -band 0xFF
                                 $null = $___converted.Add($___register)
 
@@ -83,7 +89,7 @@ function HestiaKERNEL-To-UTF16-From-Unicode {
                         $___register16 = $___register16 -band 0x3FF
                         $___register16 += 0xD800
                         switch ($___endian) {
-                        { $_ -in "le", "LE", "little", "Little", "LITTLE" } {
+                        ${env:HestiaKERNEL_ENDIAN_LITTLE} {
                                 $___register = $___register16 -band 0xFF
                                 $null = $___converted.Add($___register)
 
@@ -101,7 +107,7 @@ function HestiaKERNEL-To-UTF16-From-Unicode {
                         $___register16 = $___register16 -band 0x3FF
                         $___register16 += 0xDC00
                         switch ($___endian) {
-                        { $_ -in "le", "LE", "little", "Little", "LITTLE" } {
+                        ${env:HestiaKERNEL_ENDIAN_LITTLE} {
                                 $___register = $___register16 -band 0xFF
                                 $null = $___converted.Add($___register)
 

--- a/init/services/HestiaKERNEL/To_UTF16_From_Unicode.sh
+++ b/init/services/HestiaKERNEL/To_UTF16_From_Unicode.sh
@@ -28,7 +28,9 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/HestiaKERNEL/Endian.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode.sh"
 
 
 
@@ -55,9 +57,9 @@ HestiaKERNEL_To_UTF16_From_Unicode() {
 
         # execute
         ___converted=""
-        if [ ! "$2" = "" ]; then
+        if [ "$2" = "$HestiaKERNEL_UTF_BOM" ]; then
                 case "$3" in
-                "le"|"LE"|"little"|"Little"|"LITTLE")
+                "$HestiaKERNEL_ENDIAN_LITTLE")
                         # UTF16LE BOM - 0xFF, 0xFE
                         ___converted="255, 254"
                         ;;
@@ -84,7 +86,7 @@ HestiaKERNEL_To_UTF16_From_Unicode() {
                 if [ $___char -lt 200000 ]; then
                         # char < 0x10000
                         case "$3" in
-                        "le"|"LE"|"little"|"Little"|"LITTLE")
+                        "$HestiaKERNEL_ENDIAN_LITTLE")
                                 ___register=$(($___char & 0xFF))
                                 ___converted="${___converted}$(printf -- "%d" "$___register"), "
 
@@ -109,7 +111,7 @@ HestiaKERNEL_To_UTF16_From_Unicode() {
                         ___register16=$(($___register16 & 0x3FF))
                         ___register16=$(($___register16 + 0xD800))
                         case "$3" in
-                        "le"|"LE"|"little"|"Little"|"LITTLE")
+                        "$HestiaKERNEL_ENDIAN_LITTLE")
                                 ___register=$(($___register16 & 0xFF))
                                 ___converted="${___converted}$(printf -- "%d" "$___register"), "
 
@@ -130,7 +132,7 @@ HestiaKERNEL_To_UTF16_From_Unicode() {
                         ___register16=$(($___char & 0x3FF))
                         ___register16=$(($___register16 + 0xDC00))
                         case "$3" in
-                        "le"|"LE"|"little"|"Little"|"LITTLE")
+                        "$HestiaKERNEL_ENDIAN_LITTLE")
                                 ___register=$(($___register16 & 0xFF))
                                 ___converted="${___converted}$(printf -- "%d" "$___register"), "
 

--- a/init/services/HestiaKERNEL/To_UTF32_From_Unicode.ps1
+++ b/init/services/HestiaKERNEL/To_UTF32_From_Unicode.ps1
@@ -27,6 +27,12 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Endian.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode.ps1"
+
+
+
+
 function HestiaKERNEL-To-UTF32-From-Unicode {
         param (
                 [uint32[]]$___content,
@@ -43,9 +49,9 @@ function HestiaKERNEL-To-UTF32-From-Unicode {
 
         # execute
         [System.Collections.Generic.List[uint8]]$___converted = @()
-        if ($___bom -ne "") {
+        if ($___bom -eq ${env:HestiaKERNEL_UTF_BOM}) {
                 switch ($___endian) {
-                { $_ -in "le", "LE", "little", "Little", "LITTLE" } {
+                ${env:HestiaKERNEL_ENDIAN_LITTLE} {
                         # UTF32LE BOM - 0xFF, 0xFE, 0x00, 0x00
                         $null = $___converted.Add(0xFF)
                         $null = $___converted.Add(0xFE)
@@ -64,7 +70,7 @@ function HestiaKERNEL-To-UTF32-From-Unicode {
                 # convert to UTF-32 bytes list
                 ## 0x00000 - 0x10000 - 0x10FFFF (surrogate pair region)
                 switch ($___endian) {
-                { $_ -in "le", "LE", "little", "Little", "LITTLE" } {
+                ${env:HestiaKERNEL_ENDIAN_LITTLE} {
                         $___register = $___char -band 0xFF
                         $null = $___converted.Add($___register)
 

--- a/init/services/HestiaKERNEL/To_UTF32_From_Unicode.sh
+++ b/init/services/HestiaKERNEL/To_UTF32_From_Unicode.sh
@@ -28,7 +28,9 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/HestiaKERNEL/Endian.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode.sh"
 
 
 
@@ -55,9 +57,9 @@ HestiaKERNEL_To_UTF32_From_Unicode() {
 
         # execute
         ___converted=""
-        if [ ! "$2" = "" ]; then
+        if [ "$2" = "$HestiaKERNEL_UTF_BOM" ]; then
                 case "$3" in
-                "le"|"LE"|"little"|"Little"|"LITTLE")
+                "$HestiaKERNEL_ENDIAN_LITTLE")
                         # UTF32LE BOM - 0xFF, 0xFE, 0x00, 0x00
                         ___converted="255, 254, 0, 0"
                         ;;
@@ -82,7 +84,7 @@ HestiaKERNEL_To_UTF32_From_Unicode() {
                 # IMPORTANT NOTICE
                 #   (1) using single code-point algorithm (not the 2 16-bits).
                 case "$3" in
-                "le"|"LE"|"little"|"Little"|"LITTLE")
+                "$HestiaKERNEL_ENDIAN_LITTLE")
                         ___register=$(($___char & 0xFF))
                         ___converted="${___converted}$(printf -- "%d" "$___register"), "
 

--- a/init/services/HestiaKERNEL/To_UTF8_From_Unicode.ps1
+++ b/init/services/HestiaKERNEL/To_UTF8_From_Unicode.ps1
@@ -27,20 +27,33 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode.ps1"
+
+
+
+
 function HestiaKERNEL-To-UTF8-From-Unicode {
         param (
-                [uint32[]]$___content
+                [uint32[]]$___content,
+                [string]$___bom
         )
 
 
         # validate input
-        if ($___content) {
+        if ($___content.Length -eq 0) {
                 return [uint8[]]@()
         }
 
 
         # execute
         [System.Collections.Generic.List[uint8]]$___converted = @()
+        if ($___bom -eq ${env:HestiaKERNEL_UTF_BOM}) {
+                # UTF-8 BOM - 0xEF, 0xBB, 0xBF
+                $null = $___converted.Add(0xEF)
+                $null = $___converted.Add(0xBB)
+                $null = $___converted.Add(0xBF)
+        }
+
         foreach ($___char in $___content) {
                 # convert to UTF-8 bytes list
                 # IMPORTANT NOTICE

--- a/init/services/HestiaKERNEL/To_UTF8_From_Unicode.sh
+++ b/init/services/HestiaKERNEL/To_UTF8_From_Unicode.sh
@@ -29,6 +29,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 . "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode.sh"
 
 
 
@@ -54,7 +55,7 @@ HestiaKERNEL_To_UTF8_From_Unicode() {
 
         # execute
         ___converted=""
-        if [ ! "$2" = "" ]; then
+        if [ "$2" = "$HestiaKERNEL_UTF_BOM" ]; then
                 # UTF-8 BOM - 0xEF, 0xBB, 0xBF
                 ___converted="239, 187, 191"
         fi

--- a/init/services/HestiaKERNEL/Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode.ps1
@@ -44,6 +44,13 @@
 
 
 
+# BOM type
+${env:HestiaKERNEL_UTF_NO_BOM} = 0      # default
+${env:HestiaKERNEL_UTF_BOM} = 1
+
+
+
+
 # UTF encoding type
 ${env:HestiaKERNEL_UTF8} = 0            # default
 ${env:HestiaKERNEL_UTF8_BOM} = 1

--- a/init/services/HestiaKERNEL/Vanilla.sh.ps1
+++ b/init/services/HestiaKERNEL/Vanilla.sh.ps1
@@ -32,10 +32,12 @@ echo \" <<'RUN_AS_POWERSHELL' >/dev/null # " | Out-Null
 ################################################################################
 # Windows POWERSHELL Codes                                                     #
 ################################################################################
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Endian.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Error_Codes.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Get_String_Encoder.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Is_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Run_Parallel_Sentinel.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\To_String_From_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_Unicode_From_String.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF8_From_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF16_From_Unicode.ps1"
@@ -54,10 +56,12 @@ RUN_AS_POWERSHELL
 ################################################################################
 # Unix Main Codes                                                              #
 ################################################################################
+. "${LIBS_HESTIA}/HestiaKERNEL/Endian.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Get_String_Encoder.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Is_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Run_Parallel_Sentinel.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/To_String_From_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_Unicode_From_String.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_UTF8_From_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_UTF16_From_Unicode.sh"


### PR DESCRIPTION
Since level 2 libraries need a certain string processing function, we got to port the primitive functions into HestiaKERNEL. Hence, let's deal with To_String_From_Unicode function.

This patch ports To_String_From_Unicode primitive function in init/ directory.