### PR TITLE
init: ported Trim_Left_{String,Unicode} primitive function

### DIFF
--- a/init/services/HestiaKERNEL/Is_Unicode.sh
+++ b/init/services/HestiaKERNEL/Is_Unicode.sh
@@ -46,7 +46,7 @@ HestiaKERNEL_Is_Unicode() {
 
         # execute
         case "$1" in
-        *[!0123456789,\ ]*)
+        *[!0123456789,\ \-\+]*)
                 printf -- "%d" $HestiaKERNEL_ERROR_DATA_INVALID
                 return $HestiaKERNEL_ERROR_DATA_INVALID
                 ;;

--- a/init/services/HestiaKERNEL/To_Lowercase_String.sh
+++ b/init/services/HestiaKERNEL/To_Lowercase_String.sh
@@ -61,12 +61,13 @@ HestiaKERNEL_To_Lowercase_String() {
                 return $HestiaKERNEL_ERROR_BAD_EXEC
         fi
 
-
-        # report status
-        printf -- "%s" "$(HestiaKERNEL_To_String_From_Unicode "$___content")"
-        if [ $? -ne $HestiaKERNEL_ERROR_OK ]; then
+        ___content="$(HestiaKERNEL_To_String_From_Unicode "$___content")"
+        if [ "$___content" = "" ]; then
+                printf -- "%s" "$1"
                 return $HestiaKERNEL_ERROR_BAD_EXEC
         fi
 
+
+        # report status
         return $HestiaKERNEL_ERROR_OK
 }

--- a/init/services/HestiaKERNEL/To_String_From_Unicode.sh
+++ b/init/services/HestiaKERNEL/To_String_From_Unicode.sh
@@ -51,17 +51,37 @@ HestiaKERNEL_To_String_From_Unicode() {
 
 
         # execute
+        ## ensure all unicode are valid --> replace unsupported to '?'
+        ___content="$1"
+        ___converted=""
+        while [ ! "$___content" = "" ]; do
+                # get character
+                ___codepoint="${___content%%, *}"
+                ___content="${___content#"$___codepoint"}"
+                if [ "${___content%"${___content#?}"}" = "," ]; then
+                        ___content="${___content#, }"
+                fi
+
+                # check for valid codepoint
+                if [ $___codepoint -lt 0 ]; then
+                        ___codepoint=63 # change to '?'
+                fi
+
+                ___converted="${___converted}${___codepoint}, "
+        done
+
+
         # process HestiaKERNEL.Unicode data type
-        ___utf=""
+        ___content="${___converted%, }"
         case "$(HestiaKERNEL_Get_String_Encoder)" in
-        "$HestiaKERNEL_UTF8")
-                ___utf="$(HestiaKERNEL_To_UTF8_From_Unicode "$1")"
+        $HestiaKERNEL_UTF8)
+                ___content="$(HestiaKERNEL_To_UTF8_From_Unicode "$___content")"
                 ;;
-        "$HestiaKERNEL_UTF16BE")
-                ___utf="$(HestiaKERNEL_To_UTF16_From_Unicode "$1")"
+        $HestiaKERNEL_UTF16BE)
+                ___content="$(HestiaKERNEL_To_UTF16_From_Unicode "$___content")"
                 ;;
-        "$HestiaKERNEL_UTF32BE")
-                ___utf="$(HestiaKERNEL_To_UTF32_From_Unicode "$1")"
+        $HestiaKERNEL_UTF32BE)
+                ___content="$(HestiaKERNEL_To_UTF32_From_Unicode "$___content")"
                 ;;
         *)
                 printf -- ""
@@ -69,19 +89,16 @@ HestiaKERNEL_To_String_From_Unicode() {
                 ;;
         esac
 
-        if [ "$___utf" = "" ]; then
-                printf -- ""
-                return $HestiaKERNEL_ERROR_DATA_INVALID
-        fi
-
         ___converted=""
-        while [ ! "$___utf" = "" ]; do
-                ___byte="${___utf%%, *}"
-                ___converted="${___converted}$(printf -- '\%o' "$___byte")"
-                ___utf="${___utf#"$___byte"}"
-                if [ "${___utf%"${___utf#?}"}" = "," ]; then
-                        ___utf="${___utf#, }"
+        while [ ! "$___content" = "" ]; do
+                # get character
+                ___byte="${___content%%, *}"
+                ___content="${___content#"$___byte"}"
+                if [ "${___content%"${___content#?}"}" = "," ]; then
+                        ___content="${___content#, }"
                 fi
+
+                ___converted="${___converted}$(printf -- '\%o' "$___byte")"
         done
 
 

--- a/init/services/HestiaKERNEL/To_Titlecase_String.sh
+++ b/init/services/HestiaKERNEL/To_Titlecase_String.sh
@@ -61,12 +61,13 @@ HestiaKERNEL_To_Titlecase_String() {
                 return $HestiaKERNEL_ERROR_BAD_EXEC
         fi
 
-
-        # report status
-        printf -- "%s" "$(HestiaKERNEL_To_String_From_Unicode "$___content")"
-        if [ $? -ne $HestiaKERNEL_ERROR_OK ]; then
+        ___content="$(HestiaKERNEL_To_String_From_Unicode "$___content")"
+        if [ "$___content" = "" ]; then
+                printf -- "%s" "$1"
                 return $HestiaKERNEL_ERROR_BAD_EXEC
         fi
 
+
+        # report status
         return $HestiaKERNEL_ERROR_OK
 }

--- a/init/services/HestiaKERNEL/Trim_Left_String.ps1
+++ b/init/services/HestiaKERNEL/Trim_Left_String.ps1
@@ -1,4 +1,3 @@
-#!/bin/sh
 # Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
 #
 #
@@ -28,46 +27,46 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-. "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
-. "${LIBS_HESTIA}/HestiaKERNEL/To_Uppercase_Unicode.sh"
-. "${LIBS_HESTIA}/HestiaKERNEL/To_Unicode_From_String.sh"
-. "${LIBS_HESTIA}/HestiaKERNEL/To_String_From_Unicode.sh"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Trim_Left_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\To_Unicode_From_String.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\To_String_From_Unicode.ps1"
 
 
 
 
-HestiaKERNEL_To_Uppercase_String() {
-        #___input="$1"
-        #___locale="$2"
+function HestiaKERNEL-Trim-Left-String {
+        param (
+                [string]$___input,
+                [string]$___charset
+        )
 
 
         # validate input
-        if [ "$1" = "" ]; then
-                printf -- ""
-                return $HestiaKERNEL_ERROR_DATA_EMPTY
-        fi
+        if (
+                ($___input -eq "") -or
+                ($___charset -eq "")
+        ) {
+                return $___input
+        }
 
 
         # execute
-        ___content="$(HestiaKERNEL_To_Unicode_From_String "$1")"
-        if [ "$___content" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_DATA_INVALID
-        fi
+        $___content = HestiaKERNEL-To-Unicode-From-String $___input
+        if ($___content.Length -eq 0) {
+                return $___input
+        }
 
-        ___content="$(HestiaKERNEL_To_Uppercase_Unicode "$___content")"
-        if [ "$___content" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_BAD_EXEC
-        fi
+        $___chars = HestiaKERNEL-To-Unicode-From-String $___charset
+        if ($___chars.Length -eq 0) {
+                return $___input
+        }
 
-        ___content="$(HestiaKERNEL_To_String_From_Unicode "$___content")"
-        if [ "$___content" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_BAD_EXEC
-        fi
+        $___content = HestiaKERNEL-Trim-Left-Unicode $___content $___chars
+        if ($___content.Length -eq 0) {
+                return $___input
+        }
 
 
         # report status
-        return $HestiaKERNEL_ERROR_OK
+        return HestiaKERNEL-To-String-From-Unicode $___content
 }

--- a/init/services/HestiaKERNEL/Trim_Left_String.sh
+++ b/init/services/HestiaKERNEL/Trim_Left_String.sh
@@ -29,21 +29,26 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 . "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
-. "${LIBS_HESTIA}/HestiaKERNEL/To_Uppercase_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Trim_Left_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_Unicode_From_String.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_String_From_Unicode.sh"
 
 
 
 
-HestiaKERNEL_To_Uppercase_String() {
-        #___input="$1"
-        #___locale="$2"
+HestiaKERNEL_Trim_Left_String() {
+        #___content="$1"
+        #___charset="$2"
 
 
         # validate input
         if [ "$1" = "" ]; then
-                printf -- ""
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
+        fi
+
+        if [ "$2" = "" ]; then
+                printf -- "%s" "$1"
                 return $HestiaKERNEL_ERROR_DATA_EMPTY
         fi
 
@@ -55,7 +60,13 @@ HestiaKERNEL_To_Uppercase_String() {
                 return $HestiaKERNEL_ERROR_DATA_INVALID
         fi
 
-        ___content="$(HestiaKERNEL_To_Uppercase_Unicode "$___content")"
+        ___chars="$(HestiaKERNEL_To_Unicode_From_String "$2")"
+        if [ "$___chars" = "" ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_DATA_INVALID
+        fi
+
+        ___content="$(HestiaKERNEL_Trim_Left_Unicode "$___content" "$___chars")"
         if [ "$___content" = "" ]; then
                 printf -- "%s" "$1"
                 return $HestiaKERNEL_ERROR_BAD_EXEC
@@ -66,6 +77,7 @@ HestiaKERNEL_To_Uppercase_String() {
                 printf -- "%s" "$1"
                 return $HestiaKERNEL_ERROR_BAD_EXEC
         fi
+        printf -- "%s" "$___content"
 
 
         # report status

--- a/init/services/HestiaKERNEL/Trim_Left_Unicode.sh
+++ b/init/services/HestiaKERNEL/Trim_Left_Unicode.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# BSD 3-Clause License
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+. "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Is_Unicode.sh"
+
+
+
+
+HestiaKERNEL_Trim_Left_Unicode() {
+        #___content_unicode="$1"
+        #___charset_unicode="$2"
+
+
+        # validate input
+        if [ $(HestiaKERNEL_Is_Unicode "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
+        fi
+
+        if [ $(HestiaKERNEL_Is_Unicode "$2") -ne $HestiaKERNEL_ERROR_OK ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_DATA_EMPTY
+        fi
+
+
+        # execute
+        ## IMPORTANT NOTICE
+        ## POSIX Shell's UNIX regex cannot recognize anything outside Latin-1
+        ## script. Therefore, manual algorithmic handling is required.
+        ___content_unicode="$1"
+        ___charset_unicode="$2"
+        ___converted=""
+        while [ ! "$___content_unicode" = "" ]; do
+                # get current character
+                ___current="${___content_unicode%%, *}"
+                ___content_unicode="${___content_unicode#"$___current"}"
+                if [ "${___content_unicode%"${___content_unicode#?}"}" = "," ]; then
+                        ___content_unicode="${___content_unicode#, }"
+                fi
+
+
+                # get char from charset character
+                ___charset_list="$___charset_unicode"
+                while [ ! "$___charset_list" = "" ]; do
+                        ___char="${___charset_list%%, *}"
+                        ___charset_list="${___charset_list#"$___char"}"
+                        if [ "${___charset_list%"${___charset_list#?}"}" = "," ]; then
+                                ___charset_list="${___charset_list#, }"
+                        fi
+
+                        if [ "$___current" = "$___char" ]; then
+                                ___charset_list=""
+                                break # exit early from O(m^2) timing ASAP
+                        fi
+                done
+
+                if [ ! "$___current" = "$___char" ]; then
+                        # It's an mismatched
+                        ___converted="${___current}, ${___content_unicode}"
+                        break
+                fi
+
+
+                # it's a match - do nothing and continue to next character
+        done
+
+
+        # report status
+        printf -- "%s" "${___converted%, }"
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/services/HestiaKERNEL/Vanilla.sh.ps1
+++ b/init/services/HestiaKERNEL/Vanilla.sh.ps1
@@ -49,6 +49,8 @@ echo \" <<'RUN_AS_POWERSHELL' >/dev/null # " | Out-Null
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF8_From_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF16_From_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\To_UTF32_From_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Trim_Left_String.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Trim_Left_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode.ps1"
 ################################################################################
 # Windows POWERSHELL Codes                                                     #
@@ -80,6 +82,8 @@ RUN_AS_POWERSHELL
 . "${LIBS_HESTIA}/HestiaKERNEL/To_UTF8_From_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_UTF16_From_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/To_UTF32_From_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Trim_Left_String.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Trim_Left_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode.sh"
 ################################################################################
 # Unix Main Codes                                                              #

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -111,13 +111,8 @@ ${env:LIBS_HESTIA} = "${env:LIBS_UPSCALER}\services"
 . "${env:LIBS_UPSCALER}\services\i18n\report-success.ps1"
 
 ### TEST ZONE
-. "${env:LIBS_HESTIA}\HestiaKERNEL\To_Uppercase_String.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\To_Lowercase_String.ps1"
-. "${env:LIBS_HESTIA}\HestiaKERNEL\To_Titlecase_String.ps1"
-Write-Host "$(HestiaKERNEL-To-Uppercase-String "e你feeeff你你aerg aegE你F")"
-Write-Host "$(HestiaKERNEL-To-Lowercase-String "E你FEEEFF你你AERG AEGE你F")"
-Write-Host "$(HestiaKERNEL-To-Titlecase-String "e你feeeff你你aerg aegE你F")"
-Write-Host "$(HestiaKERNEL-To-Titlecase-String "E你FEEEFF你你AERG AEGE你F")"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Trim_Left_String.ps1"
+Write-Host "$(HestiaKERNEL-Trim-Left-String "e你feeeff你你aerg aegE你F" "e你a")"
 
 
 

--- a/init/start.sh
+++ b/init/start.sh
@@ -102,13 +102,8 @@ LIBS_HESTIA="${LIBS_UPSCALER}/services"
 . "${LIBS_UPSCALER}/services/i18n/report-success.sh"
 
 ### TEST ZONE
-. "${LIBS_HESTIA}/HestiaKERNEL/To_Uppercase_String.sh"
-. "${LIBS_HESTIA}/HestiaKERNEL/To_Lowercase_String.sh"
-. "${LIBS_HESTIA}/HestiaKERNEL/To_Titlecase_String.sh"
-printf -- "%s\n" "$(HestiaKERNEL_To_Uppercase_String "e你feeeff你你aerg aegE你F")"
-printf -- "%s\n" "$(HestiaKERNEL_To_Lowercase_String "E你FEEEFF你你AERG AEGE你F")"
-printf -- "%s\n" "$(HestiaKERNEL_To_Titlecase_String "E你FEEEFF你你AERG AEGE你F")"
-printf -- "%s\n" "$(HestiaKERNEL_To_Titlecase_String "e你feeeff你你aerg aegE你F")"
+. "${LIBS_HESTIA}/HestiaKERNEL/Trim_Left_String.sh"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Trim_Left_String "e你feeeff你你aerg aegE你F" "e你a")"
 
 
 


### PR DESCRIPTION
Since Level 1 Hestia libraries requires a number of string processing functions, we have to port the Trim_Left primitive functions into HestiaKERNEL library. Hence, let's do this.

This patch ports Trim_Left_{String,Unicode} primitive function into init/ directory.