### PR TITLE
init: ported Get_First_{String,Unicode} primitive function

### DIFF
--- a/init/services/HestiaKERNEL/Get_First_Character.ps1
+++ b/init/services/HestiaKERNEL/Get_First_Character.ps1
@@ -1,0 +1,45 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Get_First_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\To_String_From_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\To_Unicode_From_String.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode.ps1"
+
+
+
+
+function HestiaKERNEL-Get-First-Character {
+        param (
+                [string]$___input_string
+        )
+
+
+        # validate input
+        if ($___input_string -eq "") {
+                return ""
+        }
+
+
+        # execute
+        $___unicodes = HestiaKERNEL-To-Unicode-From-String $___input_string
+        if ($___unicodes.Length -le 0) {
+                return ""
+        }
+
+        $___unicode = HestiaKERNEL-Get-First-Unicode $___unicodes
+        if ($___unicode -eq ${env:HestiaKERNEL_UNICODE_ERROR}) {
+                return ""
+        }
+
+
+        # execute
+        return HestiaKERNEL-To-String-From-Unicode $___unicode
+}

--- a/init/services/HestiaKERNEL/Get_First_Character.sh
+++ b/init/services/HestiaKERNEL/Get_First_Character.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Get_First_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/To_String_From_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/To_Unicode_From_String.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode.sh"
+
+
+
+
+HestiaKERNEL_Get_First_Character() {
+        #___input_string="$1"
+
+
+        # validate input
+        if [ "$1" = "" ]; then
+                printf -- ""
+                return $HestiaKERNEL_ERROR_DATA_EMPTY
+        fi
+
+
+        # execute
+        ___unicodes="$(HestiaKERNEL_To_Unicode_From_String "$1")"
+        if [ "$___unicodes" = "" ]; then
+                printf -- ""
+                return $HestiaKERNEL_ERROR_DATA_INVALID
+        fi
+
+        ___unicode="$(HestiaKERNEL_Get_First_Unicode "$___unicodes")"
+        if [ "$___unicode" = "${HestiaKERNEL_UNICODE_ERROR}" ]; then
+                printf -- ""
+                return $HestiaKERNEL_ERROR_DATA_INVALID
+        fi
+
+        printf -- "%s" "$(HestiaKERNEL_To_String_From_Unicode "$___unicode")"
+        if [ $? -ne $HestiaKERNEL_ERROR_OK ]; then
+                return $HestiaKERNEL_ERROR_BAD_EXEC
+        fi
+
+
+        # report status
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/services/HestiaKERNEL/Get_First_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Get_First_Unicode.ps1
@@ -1,0 +1,30 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode.ps1"
+
+
+
+
+function HestiaKERNEL-Get-First-Unicode {
+        param (
+                [uint32[]]$___content_unicode
+        )
+
+
+        # validate input
+        if ($___content_unicode.Length -le 0) {
+                return ${env:HestiaKERNEL_UNICODE_ERROR}
+        }
+
+
+        # execute
+        return $___content_unicode[0]
+}

--- a/init/services/HestiaKERNEL/Get_First_Unicode.sh
+++ b/init/services/HestiaKERNEL/Get_First_Unicode.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Is_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode.sh"
+
+
+
+
+HestiaKERNEL_Get_First_Unicode() {
+        #___content_unicode="$1"
+
+
+        # validate input
+        if [ "$1" = "" ]; then
+                printf -- "%s" "$HestiaKERNEL_UNICODE_ERROR"
+                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
+        fi
+
+        if [ "$(HestiaKERNEL_Is_Unicode "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
+                printf -- "%s" "$HestiaKERNEL_UNICODE_ERROR"
+                return $HestiaKERNEL_ERROR_ENTITY_INVALID
+        fi
+
+
+        # execute
+        printf -- "%d" "${1%%, *}"
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/services/HestiaKERNEL/Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode.ps1
@@ -25,6 +25,12 @@
 
 
 
+# Error type
+${env:HestiaKERNEL_UNICODE_ERROR} = [uint32]4294967295 # 0xFFFFFFFF
+
+
+
+
 # BOM type
 ${env:HestiaKERNEL_UTF_NO_BOM} = 0      # default
 ${env:HestiaKERNEL_UTF_BOM} = 1

--- a/init/services/HestiaKERNEL/Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode.sh
@@ -20,6 +20,12 @@
 
 
 
+# Error type
+HestiaKERNEL_UNICODE_ERROR=4294967295 # 0xFFFFFFFF
+
+
+
+
 # BOM type
 HestiaKERNEL_UTF_NO_BOM=0       # default
 HestiaKERNEL_UTF_BOM=1

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -112,6 +112,11 @@ ${env:LIBS_HESTIA} = "${env:LIBS_UPSCALER}\services"
 . "${env:LIBS_UPSCALER}\services\i18n\report-success.ps1"
 
 ### TEST ZONE
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Get_First_Character.ps1"
+Write-Host "$(HestiaKERNEL-Get-First-Character '')"
+Write-Host "$(HestiaKERNEL-Get-First-Character "s")"
+Write-Host "$(HestiaKERNEL-Get-First-Character "sta")"
+
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Is_Empty_String.ps1"
 Write-Host "$(HestiaKERNEL-Is-Empty-String '')"
 Write-Host "$(HestiaKERNEL-Is-Empty-String "a")"

--- a/init/start.sh
+++ b/init/start.sh
@@ -102,6 +102,11 @@ LIBS_HESTIA="${LIBS_UPSCALER}/services"
 . "${LIBS_UPSCALER}/services/i18n/report-success.sh"
 
 ### TEST ZONE
+. "${LIBS_HESTIA}/HestiaKERNEL/Get_First_Character.sh"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_First_Character "")"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_First_Character "s")"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_First_Character "sta")"
+
 . "${LIBS_HESTIA}/HestiaKERNEL/Is_Empty_String.sh"
 1>&2 printf -- "%d\n" "$(HestiaKERNEL_Is_Empty_String "")"
 1>&2 printf -- "%d\n" "$(HestiaKERNEL_Is_Empty_String "s")"


### PR DESCRIPTION
Since a number of level 1 Hestia libraries use string functions, we have to port its primitive ones into HestiaKERNEL library package. Hence, let's do this.

This patch ports Get_First_{Char,Unicode} primitive function into HestiaKERNEL library in init/ directory.