### PR TITLE
init: ported Get_Length_{String,Unicode} primitive functions

### DIFF
--- a/init/services/HestiaKERNEL/String/Get_Length_String.ps1
+++ b/init/services/HestiaKERNEL/String/Get_Length_String.ps1
@@ -1,0 +1,36 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Get_Length_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\To_Unicode_From_String.ps1"
+
+
+
+
+function HestiaKERNEL-Get-Length-String {
+        param (
+                [string]$___input_string
+        )
+
+
+        # validate input
+        if ($___input_string -eq "") {
+                return 0
+        }
+
+
+        # execute
+        $___unicodes = HestiaKERNEL-To-Unicode-From-String $___input_string
+        if ($___unicodes.Length -le 0) {
+                return 0
+        }
+
+        return HestiaKERNEL-Get-Length-Unicode $___unicodes
+}

--- a/init/services/HestiaKERNEL/String/Get_Length_String.sh
+++ b/init/services/HestiaKERNEL/String/Get_Length_String.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Get_Length_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/To_Unicode_From_String.sh"
+
+
+
+
+HestiaKERNEL_Get_Length_String() {
+        #___input_string="$1"
+
+
+        # validate input
+        if [ "$1" = "" ]; then
+                printf -- "%d" "0"
+                return $HestiaKERNEL_ERROR_DATA_EMPTY
+        fi
+
+
+        # execute
+        ___unicodes="$(HestiaKERNEL_To_Unicode_From_String "$1")"
+        if [ "$___unicodes" = "" ]; then
+                printf -- "%d" "0"
+                return $HestiaKERNEL_ERROR_DATA_INVALID
+        fi
+
+        printf -- "%d" "$(HestiaKERNEL_Get_Length_Unicode "$___unicodes")"
+
+
+        # report status
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/services/HestiaKERNEL/Unicode/Get_Length_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/Get_Length_Unicode.ps1
@@ -1,0 +1,30 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
+
+
+
+
+function HestiaKERNEL-Get-Length-Unicode {
+        param (
+                [uint32[]]$___input_unicode
+        )
+
+
+        # validate input
+        if ($(HestiaKERNEL-Is-Unicode $___input_unicode) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+                return -1
+        }
+
+
+        # execute
+        return $___input_unicode.Length
+}

--- a/init/services/HestiaKERNEL/Unicode/Get_Length_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/Get_Length_Unicode.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Is_Unicode.sh"
+
+
+
+
+HestiaKERNEL_Get_Length_Unicode() {
+        #___input_unicode="$1"
+
+
+        # validate input
+        if [ $(HestiaKERNEL_Is_Unicode "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
+                printf -- "%s" "-1"
+                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
+        fi
+
+        if [ "$1" = "" ]; then
+                printf -- "%d" "0"
+                return $HestiaKERNEL_ERROR_OK
+        fi
+
+
+        # execute
+        ___count=0
+        ___content_unicode="$1"
+        while [ ! "$___content_unicode" = "" ]; do
+                # get current character
+                ___current="${___content_unicode%%, *}"
+                ___content_unicode="${___content_unicode#"$___current"}"
+                if [ "${___content_unicode%"${___content_unicode#?}"}" = "," ]; then
+                        ___content_unicode="${___content_unicode#, }"
+                fi
+
+                ___count=$(($___count + 1))
+        done
+
+
+        # report status
+        printf -- "%d" "$___count"
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -112,6 +112,11 @@ ${env:LIBS_HESTIA} = "${env:LIBS_UPSCALER}\services"
 . "${env:LIBS_UPSCALER}\services\i18n\report-success.ps1"
 
 ### TEST ZONE
+. "${env:LIBS_HESTIA}\HestiaKERNEL\String\Get_Length_String.ps1"
+Write-Host "$(HestiaKERNEL-Get-Length-String '')"
+Write-Host "$(HestiaKERNEL-Get-Length-String "f")"
+Write-Host "$(HestiaKERNEL-Get-Length-String "f你你a")"
+
 . "${env:LIBS_HESTIA}\HestiaKERNEL\String\Get_First_Character.ps1"
 Write-Host "$(HestiaKERNEL-Get-First-Character '')"
 Write-Host "$(HestiaKERNEL-Get-First-Character "s")"

--- a/init/start.sh
+++ b/init/start.sh
@@ -102,6 +102,11 @@ LIBS_HESTIA="${LIBS_UPSCALER}/services"
 . "${LIBS_UPSCALER}/services/i18n/report-success.sh"
 
 ### TEST ZONE
+. "${LIBS_HESTIA}/HestiaKERNEL/String/Get_Length_String.sh"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_Length_String "")"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_Length_String "f")"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_Length_String "f你你a")"
+
 . "${LIBS_HESTIA}/HestiaKERNEL/String/Get_First_Character.sh"
 1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_First_Character "")"
 1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_First_Character "s")"


### PR DESCRIPTION
Since a number of level 1 Hestia libraries use string functions, we have to port its primitive ones into HestiaKERNEL library package. Hence, let's do this.

This patch ports Get_Length_{String,Unicode} primitive function into HestiaKERNEL library in init/ directory.