### PR TITLE
init: ported Trim_Prefix_{String,Unicode} primitive function

### DIFF
--- a/init/services/HestiaKERNEL/String/Trim_Prefix_String.ps1
+++ b/init/services/HestiaKERNEL/String/Trim_Prefix_String.ps1
@@ -1,0 +1,53 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\String\To_String_From_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Trim_Prefix_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\To_Unicode_From_String.ps1"
+
+
+
+
+function HestiaKERNEL-Trim-Prefix-String {
+        param (
+                [string]$___input,
+                [string]$___prefix
+        )
+
+
+        # validate input
+        if (
+                ($___input -eq "") -or
+                ($___prefix -eq "")
+        ) {
+                return $___input
+        }
+
+
+        # execute
+        $___content = HestiaKERNEL-To-Unicode-From-String $___input
+        if ($___content.Length -eq 0) {
+                return $___input
+        }
+
+        $___chars = HestiaKERNEL-To-Unicode-From-String $___prefix
+        if ($___chars.Length -eq 0) {
+                return $___input
+        }
+
+        $___content = HestiaKERNEL-Trim-Prefix-Unicode $___content $___chars
+        if ($___content.Length -eq 0) {
+                return $___input
+        }
+
+
+        # report status
+        return HestiaKERNEL-To-String-From-Unicode $___content
+}

--- a/init/services/HestiaKERNEL/String/Trim_Prefix_String.sh
+++ b/init/services/HestiaKERNEL/String/Trim_Prefix_String.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/String/To_String_From_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/To_Unicode_From_String.sh"
+
+
+
+
+HestiaKERNEL_Trim_Prefix_String() {
+        #___input="$1"
+        #___prefix="$2"
+
+
+        # validate input
+        if [ "$1" = "" ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
+        fi
+
+        if [ "$2" = "" ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_DATA_EMPTY
+        fi
+
+
+        # execute
+        ___content="$(HestiaKERNEL_To_Unicode_From_String "$1")"
+        if [ "$___content" = "" ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_DATA_INVALID
+        fi
+
+        ___chars="$(HestiaKERNEL_To_Unicode_From_String "$2")"
+        if [ "$___chars" = "" ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_DATA_INVALID
+        fi
+
+        ___content="$(HestiaKERNEL_Trim_Prefix_Unicode "$___content" "$___chars")"
+        ___content="$(HestiaKERNEL_To_String_From_Unicode "$___content")"
+        printf -- "%s" "$___content"
+
+
+        # report status
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.ps1
@@ -1,0 +1,56 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
+
+
+
+
+function HestiaKERNEL-Trim-Prefix-Unicode {
+        param (
+                [uint32[]]$___content_unicode,
+                [uint32[]]$___prefix_unicode
+        )
+
+
+        # validate input
+        if (
+                ($(HestiaKERNEL-Is-Unicode $___content_unicode) -ne ${env:HestiaKERNEL_ERROR_OK}) -or
+                ($(HestiaKERNEL-Is-Unicode $___prefix_unicode) -ne ${env:HestiaKERNEL_ERROR_OK})
+        ) {
+                return $___content_unicode
+        }
+
+        if ($___prefix_unicode.Length -gt $___content_unicode.Length) {
+                return $___content_unicode
+        }
+
+
+        # execute
+        for ($i = 0; $i -le $___prefix_unicode.Length - 1; $i++) {
+                # get current character
+                $___current = ""
+                $___current = $___content_unicode[$i]
+
+
+                # get target character
+                $___target = $___prefix_unicode[$i]
+
+
+                # bail if mismatched
+                if ($___current -ne $___target) {
+                        return $___content_unicode
+                }
+        }
+
+
+        # report status
+        return [uint32[]]$___content_unicode[$i..($___content_unicode.Length - 1)]
+}

--- a/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Is_Unicode.sh"
+
+
+
+
+HestiaKERNEL_Trim_Prefix_Unicode() {
+        #___input_content_unicode="$1"
+        #___input_prefix_unicode="$2"
+
+
+        # validate input
+        if [ $(HestiaKERNEL_Is_Unicode "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
+        fi
+
+        if [ $(HestiaKERNEL_Is_Unicode "$2") -ne $HestiaKERNEL_ERROR_OK ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_DATA_EMPTY
+        fi
+
+
+        # execute
+        ## IMPORTANT NOTICE
+        ## POSIX Shell's UNIX regex cannot recognize anything outside Latin-1
+        ## script. Therefore, manual algorithmic handling is required.
+        ___content_unicode="$1"
+        ___prefix_unicode="$2"
+        while [ ! "$___prefix_unicode" = "" ]; do
+                # get current character
+                ___current="${___content_unicode%%, *}"
+                ___content_unicode="${___content_unicode#"$___current"}"
+                if [ "${___content_unicode%"${___content_unicode#?}"}" = "," ]; then
+                        ___content_unicode="${___content_unicode#, }"
+                fi
+
+
+                # get target character
+                ___target="${___prefix_unicode%%, *}"
+                ___prefix_unicode="${___prefix_unicode#"$___target"}"
+                if [ "${___prefix_unicode%"${___prefix_unicode#?}"}" = "," ]; then
+                        ___prefix_unicode="${___prefix_unicode#, }"
+                fi
+
+
+                # bail if mismatched
+                if [ "$___current" != "$___target" ] ||
+                        ([ "$___content_unicode" = "" ] && [ ! "$___prefix_unicode" = "" ]); then
+                        printf -- "%s" "$1"
+                        return $HestiaKERNEL_ERROR_OK
+                fi
+        done
+
+
+        # report status
+        printf -- "%s" "${___content_unicode%, }"
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -112,6 +112,11 @@ ${env:LIBS_HESTIA} = "${env:LIBS_UPSCALER}\services"
 . "${env:LIBS_UPSCALER}\services\i18n\report-success.ps1"
 
 ### TEST ZONE
+. "${env:LIBS_HESTIA}\HestiaKERNEL\String\Trim_Prefix_String.ps1"
+Write-Host "$(HestiaKERNEL-Trim-Prefix-String "e你feeeff你你aerg aegE你F" '')"
+Write-Host "$(HestiaKERNEL-Trim-Prefix-String "e你feeeff你你aerg aegE你F" "e你a")"
+Write-Host "$(HestiaKERNEL-Trim-Prefix-String "e你feeeff你你aerg aegE你F" "e你f")"
+
 . "${env:LIBS_HESTIA}\HestiaKERNEL\String\Get_Length_String.ps1"
 Write-Host "$(HestiaKERNEL-Get-Length-String '')"
 Write-Host "$(HestiaKERNEL-Get-Length-String "f")"

--- a/init/start.sh
+++ b/init/start.sh
@@ -102,6 +102,11 @@ LIBS_HESTIA="${LIBS_UPSCALER}/services"
 . "${LIBS_UPSCALER}/services/i18n/report-success.sh"
 
 ### TEST ZONE
+. "${LIBS_HESTIA}/HestiaKERNEL/String/Trim_Prefix_String.sh"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Trim_Prefix_String "e你feeeff你你aerg aegE你F" "")"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Trim_Prefix_String "e你feeeff你你aerg aegE你F" "e你a")"
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_Trim_Prefix_String "e你feeeff你你aerg aegE你F" "e你f")"
+
 . "${LIBS_HESTIA}/HestiaKERNEL/String/Get_Length_String.sh"
 1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_Length_String "")"
 1>&2 printf -- "%s\n" "$(HestiaKERNEL_Get_Length_String "f")"


### PR DESCRIPTION
Since a number of level 1 Hestia libraries use string functions, we have to port its primitive ones into HestiaKERNEL library package. Hence, let's do this.

This patch ports Get_Prefix_{String,Unicode} primitive function into HestiaKERNEL library in init/ directory.