### PR TITLE
init: ported Trim_Whitespace_Right_{String,Unicode} primitive function

### DIFF
--- a/init/services/HestiaKERNEL/String/Trim_Whitespace_Right_String.ps1
+++ b/init/services/HestiaKERNEL/String/Trim_Whitespace_Right_String.ps1
@@ -1,0 +1,37 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\String\To_String_From_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Trim_Whitespace_Right_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\To_Unicode_From_String.ps1"
+
+
+
+
+function HestiaKERNEL-Trim-Whitespace-Right-String {
+        param (
+                [string]$___input
+        )
+
+
+        # validate input
+        if ($___input -eq "") {
+                return $___input
+        }
+
+
+        # execute
+        $___content = HestiaKERNEL-To-Unicode-From-String $___input
+        $___content = HestiaKERNEL-Trim-Whitespace-Right-Unicode $___content
+
+
+        # report status
+        return HestiaKERNEL-To-String-From-Unicode $___content
+}

--- a/init/services/HestiaKERNEL/String/Trim_Whitespace_Right_String.sh
+++ b/init/services/HestiaKERNEL/String/Trim_Whitespace_Right_String.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/String/To_String_From_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Trim_Whitespace_Right_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/To_Unicode_From_String.sh"
+
+
+
+
+HestiaKERNEL_Trim_Whitespace_Right_String() {
+        #___content="$1"
+
+
+        # validate input
+        if [ "$1" = "" ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
+        fi
+
+
+        # execute
+        ___content="$(HestiaKERNEL_To_Unicode_From_String "$1")"
+        if [ "$___content" = "" ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_DATA_INVALID
+        fi
+
+        ___content="$(HestiaKERNEL_Trim_Whitespace_Right_Unicode "$___content")"
+        printf -- "%s" "$(HestiaKERNEL_To_String_From_Unicode "$___content")"
+
+
+        # report status
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/services/HestiaKERNEL/Unicode/Trim_Whitespace_Right_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Whitespace_Right_Unicode.ps1
@@ -1,0 +1,54 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Errors\Error_Codes.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Whitespace_Unicode.ps1"
+
+
+
+
+function HestiaKERNEL-Trim-Whitespace-Right-Unicode {
+        param (
+                [uint32[]]$___content_unicode
+        )
+
+
+        # validate input
+        if ($(HestiaKERNEL-Is-Unicode $___content_unicode) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+                return $___content_unicode
+        }
+
+
+        # execute
+        $___index = $___content_unicode.Length - 1
+        for (; $___index -ge 0; $___index--) {
+                # get current character
+                $___current = $___content_unicode[$___index]
+
+
+                # skip if matched
+                if ($(HestiaKERNEL-Is-Whitespace-Unicode $___current) -eq ${env:HestiaKERNEL_ERROR_OK}) {
+                        continue
+                }
+
+
+                # mismatched so stop the scan
+                break
+        }
+
+        if ($___index -le 0) {
+                return [uint32[]]@()
+        }
+
+
+        # report status
+        return [uint32[]]$___content_unicode[0..$___index]
+}

--- a/init/services/HestiaKERNEL/Unicode/Trim_Whitespace_Right_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Whitespace_Right_Unicode.sh
@@ -1,0 +1,55 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Is_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Is_Whitespace_Unicode.sh"
+
+
+
+
+HestiaKERNEL_Trim_Whitespace_Right_Unicode() {
+        #___content_unicode="$1"
+
+
+        # validate input
+        if [ "$(HestiaKERNEL_Is_Unicode "$1")" -ne $HestiaKERNEL_ERROR_OK ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
+        fi
+
+
+        # execute
+        ___content_unicode="$1"
+        while [ ! "$___content_unicode" = "" ]; do
+                # get current character
+                ___current="${___content_unicode##*, }"
+                ___content_unicode="${___content_unicode%"$___current"}"
+                if [ "${___content_unicode#"${___content_unicode%?}"}" = " " ]; then
+                        ___content_unicode="${___content_unicode%, }"
+                fi
+
+
+                # skip if matched
+                if [ $(HestiaKERNEL_Is_Whitespace_Unicode "$___current") -eq $HestiaKERNEL_ERROR_OK ]; then
+                        continue
+                fi
+
+
+                # mismatched so stop the scan
+                ___content_unicode="${___content_unicode}, ${___current}"
+                break
+        done
+
+
+        # report status
+        printf -- "%s" "${___content_unicode%, }"
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/services/HestiaKERNEL/Vanilla.sh.ps1
+++ b/init/services/HestiaKERNEL/Vanilla.sh.ps1
@@ -53,6 +53,7 @@ echo \" <<'RUN_AS_POWERSHELL' >/dev/null # " | Out-Null
 . "${env:LIBS_HESTIA}\HestiaKERNEL\String\Trim_Right_String.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\String\Trim_Suffix_String.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\String\Trim_Whitespace_Left_String.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\String\Trim_Whitespace_Right_String.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Get_First_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Get_Last_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Empty_Unicode.ps1"
@@ -75,6 +76,7 @@ echo \" <<'RUN_AS_POWERSHELL' >/dev/null # " | Out-Null
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Trim_Right_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Trim_Suffix_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Trim_Whitespace_Left_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Trim_Whitespace_Right_Unicode.ps1"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Unicode.ps1"
 ################################################################################
 # Windows POWERSHELL Codes                                                     #
@@ -110,6 +112,7 @@ RUN_AS_POWERSHELL
 . "${LIBS_HESTIA}/HestiaKERNEL/String/Trim_Right_String.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/String/Trim_Suffix_String.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/String/Trim_Whitespace_Left_String.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/String/Trim_Whitespace_Right_String.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Get_First_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Get_Last_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Is_Empty_Unicode.sh"
@@ -132,6 +135,7 @@ RUN_AS_POWERSHELL
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Trim_Right_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Trim_Suffix_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Trim_Whitespace_Left_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Trim_Whitespace_Right_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Unicode.sh"
 ################################################################################
 # Unix Main Codes                                                              #

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -118,6 +118,12 @@ Write-Host "|$(HestiaKERNEL-Trim-Whitespace-Left-String "    ")|"
 Write-Host "|$(HestiaKERNEL-Trim-Whitespace-Left-String "    e你feeeff你你aerg aegE你F    ")|"
 Write-Host "|$(HestiaKERNEL-Trim-Whitespace-Left-String "e你feeeff你你aerg aegE你F    ")|"
 
+. "${env:LIBS_HESTIA}\HestiaKERNEL\String\Trim_Whitespace_Right_String.ps1"
+Write-Host "|$(HestiaKERNEL-Trim-Whitespace-Right-String '')|"
+Write-Host "|$(HestiaKERNEL-Trim-Whitespace-Right-String "    ")|"
+Write-Host "|$(HestiaKERNEL-Trim-Whitespace-Right-String "    e你feeeff你你aerg aegE你F    ")|"
+Write-Host "|$(HestiaKERNEL-Trim-Whitespace-Right-String "    e你feeeff你你aerg aegE你F")|"
+
 . "${env:LIBS_HESTIA}\HestiaKERNEL\String\Trim_Prefix_String.ps1"
 Write-Host "$(HestiaKERNEL-Trim-Prefix-String "e你feeeff你你aerg aegE你F" '')"
 Write-Host "$(HestiaKERNEL-Trim-Prefix-String "e你feeeff你你aerg aegE你F" "e你feeeff你你aerg aegE你FX")"

--- a/init/start.sh
+++ b/init/start.sh
@@ -108,6 +108,12 @@ LIBS_HESTIA="${LIBS_UPSCALER}/services"
 1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_Left_String "    e你feeeff你你aerg aegE你F    ")"
 1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_Left_String "e你feeeff你你aerg aegE你F    ")"
 
+. "${LIBS_HESTIA}/HestiaKERNEL/String/Trim_Whitespace_Right_String.sh"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_Right_String "")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_Right_String "    ")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_Right_String "    e你feeeff你你aerg aegE你F    ")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_Right_String "    e你feeeff你你aerg aegE你F")"
+
 . "${LIBS_HESTIA}/HestiaKERNEL/String/Trim_Prefix_String.sh"
 1>&2 printf -- "%s\n" "$(HestiaKERNEL_Trim_Prefix_String "e你feeeff你你aerg aegE你F" "")"
 1>&2 printf -- "%s\n" "$(HestiaKERNEL_Trim_Prefix_String "e你feeeff你你aerg aegE你F" "e你feeeff你你aerg aegE你FX")"


### PR DESCRIPTION
Since a number of level 1 Hestia libraries use string functions, we have to port its primitive ones into HestiaKERNEL library package. Hence, let's do this.

This patch ports Trim_Whitespace_Right_{String,Unicode} primitive function into HestiaKERNEL library in init/ directory.