### PR TITLE
init: fixed To_UTF32_From_Unicode primitive function bug

### DIFF
--- a/init/services/HestiaKERNEL/Unicode/To_UTF32_From_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/To_UTF32_From_Unicode.ps1
@@ -32,6 +32,9 @@ function HestiaKERNEL-To-UTF32-From-Unicode {
 
         # execute
         [System.Collections.Generic.List[byte]]$___converted = @()
+
+
+        # prefix BOM if requested
         if ($___bom -eq ${env:HestiaKERNEL_UTF_BOM}) {
                 switch ($___endian) {
                 ${env:HestiaKERNEL_ENDIAN_LITTLE} {
@@ -49,9 +52,9 @@ function HestiaKERNEL-To-UTF32-From-Unicode {
                 }}
         }
 
+
+        # convert to UTF-32 bytes list
         foreach ($___char in $___unicode) {
-                # convert to UTF-32 bytes list
-                ## 0x00000 - 0x10000 - 0x10FFFF (surrogate pair region)
                 switch ($___endian) {
                 ${env:HestiaKERNEL_ENDIAN_LITTLE} {
                         $___register = $___char -band 0xFF
@@ -81,7 +84,7 @@ function HestiaKERNEL-To-UTF32-From-Unicode {
                         $___register = $___register -shr 8
                         $null = $___converted.Add($___register)
 
-                        $___register = $___register -band 0xFF
+                        $___register = $___char -band 0xFF
                         $null = $___converted.Add($___register)
                 }}
         }

--- a/init/services/HestiaKERNEL/Unicode/To_UTF32_From_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/To_UTF32_From_Unicode.sh
@@ -32,19 +32,24 @@ HestiaKERNEL_To_UTF32_From_Unicode() {
 
         # execute
         ___converted=""
+
+
+        # prefix BOM if requested
         if [ "$2" = "$HestiaKERNEL_UTF_BOM" ]; then
                 case "$3" in
                 "$HestiaKERNEL_ENDIAN_LITTLE")
                         # UTF32LE BOM - 0xFF, 0xFE, 0x00, 0x00
-                        ___converted="255, 254, 0, 0"
+                        ___converted="255, 254, 0, 0, "
                         ;;
                 *)
                         # UTF32BE BOM (default) - 0x00, 0x00, 0xFE, 0xFF
-                        ___converted="0, 0, 254, 255"
+                        ___converted="0, 0, 254, 255, "
                         ;;
                 esac
         fi
 
+
+        # convert to UTF-32 bytes list
         ___content="$1"
         while [ ! "$___content" = "" ]; do
                 # get current character decimal
@@ -54,10 +59,6 @@ HestiaKERNEL_To_UTF32_From_Unicode() {
                         ___content="${___content#, }"
                 fi
 
-
-                # convert to UTF-32 bytes list
-                # IMPORTANT NOTICE
-                #   (1) using single code-point algorithm (not the 2 16-bits).
                 case "$3" in
                 "$HestiaKERNEL_ENDIAN_LITTLE")
                         ___register=$(($___char & 0xFF))

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -404,9 +404,9 @@ Write-Host "$(HestiaKERNEL-To-UTF32-From-Unicode @(20320, 97, 22909, 98) ${env:H
 Write-Host "$(HestiaKERNEL-To-UTF32-From-Unicode @(20320, 97, 22909, 98) ${env:HestiaKERNEL_UTF_BOM})"
 ### expect 0, 0, 254, 255, 0, 0, 79, 96, 0, 0, 0, 97, 0, 0, 89, 125, 0, 0, 0, 98
 Write-Host "$(HestiaKERNEL-To-UTF32-From-Unicode @(20320, 97, 22909, 98) ${env:HestiaKERNEL_UTF_BOM} ${env:HestiaKERNEL_ENDIAN_BIG})"
-### expect 255, 254, 0, 0, 96, 79, 0, 0, 97, 0, 0, 0, 125, 89, 0, 0, 98, 0, 0, 0
-Write-Host "$(HestiaKERNEL-To-UTF32-From-Unicode @(20320, 97, 22909, 98) ${env:HestiaKERNEL_UTF_BOM} ${env:HestiaKERNEL_ENDIAN_LITTLE})"
 ### expect 0, 0, 254, 255, 0, 0, 79, 96, 0, 0, 0, 97, 0, 0, 89, 125, 0, 0, 0, 98
+Write-Host "$(HestiaKERNEL-To-UTF32-From-Unicode @(20320, 97, 22909, 98) ${env:HestiaKERNEL_UTF_BOM} ${env:HestiaKERNEL_ENDIAN_LITTLE})"
+### expect 255, 254, 0, 0, 96, 79, 0, 0, 97, 0, 0, 0, 125, 89, 0, 0, 98, 0, 0, 0
 Write-Host "----"
 
 

--- a/init/start.sh
+++ b/init/start.sh
@@ -393,9 +393,9 @@ LIBS_HESTIA="${LIBS_UPSCALER}/services"
 1>&2 printf -- "%s\n" "$(HestiaKERNEL_To_UTF32_From_Unicode "20320, 97, 22909, 98" "$HestiaKERNEL_UTF_BOM")"
 ### expect 0, 0, 254, 255, 0, 0, 79, 96, 0, 0, 0, 97, 0, 0, 89, 125, 0, 0, 0, 98
 1>&2 printf -- "%s\n" "$(HestiaKERNEL_To_UTF32_From_Unicode "20320, 97, 22909, 98" "$HestiaKERNEL_UTF_BOM" "$HestiaKERNEL_ENDIAN_BIG")"
-### expect 255, 254, 0, 0, 96, 79, 0, 0, 97, 0, 0, 0, 125, 89, 0, 0, 98, 0, 0, 0
-1>&2 printf -- "%s\n" "$(HestiaKERNEL_To_UTF32_From_Unicode "20320, 97, 22909, 98" "$HestiaKERNEL_UTF_BOM" "$HestiaKERNEL_ENDIAN_LITTLE")"
 ### expect 0, 0, 254, 255, 0, 0, 79, 96, 0, 0, 0, 97, 0, 0, 89, 125, 0, 0, 0, 98
+1>&2 printf -- "%s\n" "$(HestiaKERNEL_To_UTF32_From_Unicode "20320, 97, 22909, 98" "$HestiaKERNEL_UTF_BOM" "$HestiaKERNEL_ENDIAN_LITTLE")"
+### expect 255, 254, 0, 0, 96, 79, 0, 0, 97, 0, 0, 0, 125, 89, 0, 0, 98, 0, 0, 0
 1>&2 printf -- "----\n"
 
 


### PR DESCRIPTION
There were some minor performance bugs from To_UTF32_From_Unicode primitive function. Hence, let's fix it.

This patch fixes To_UTF32_From_Unicode primitive function bug in init/ directory.