### PR TITLE
init: fixed To_UTF8_From_Unicode primitive function bug

### DIFF
--- a/init/services/HestiaKERNEL/Unicode/To_UTF32_From_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/To_UTF32_From_Unicode.ps1
@@ -38,13 +38,13 @@ function HestiaKERNEL-To-UTF32-From-Unicode {
         if ($___bom -eq ${env:HestiaKERNEL_UTF_BOM}) {
                 switch ($___endian) {
                 ${env:HestiaKERNEL_ENDIAN_LITTLE} {
-                        # UTF32LE BOM - 0xFF, 0xFE, 0x00, 0x00
+                        # UTF32LE_BOM - 0xFF, 0xFE, 0x00, 0x00
                         $null = $___converted.Add(0xFF)
                         $null = $___converted.Add(0xFE)
                         $null = $___converted.Add(0x00)
                         $null = $___converted.Add(0x00)
                 } default {
-                        # UTF32BE BOM (default) - 0x00, 0x00, 0xFE, 0xFF
+                        # UTF32BE_BOM (default) - 0x00, 0x00, 0xFE, 0xFF
                         $null = $___converted.Add(0x00)
                         $null = $___converted.Add(0x00)
                         $null = $___converted.Add(0xFE)

--- a/init/services/HestiaKERNEL/Unicode/To_UTF32_From_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/To_UTF32_From_Unicode.sh
@@ -38,11 +38,11 @@ HestiaKERNEL_To_UTF32_From_Unicode() {
         if [ "$2" = "$HestiaKERNEL_UTF_BOM" ]; then
                 case "$3" in
                 "$HestiaKERNEL_ENDIAN_LITTLE")
-                        # UTF32LE BOM - 0xFF, 0xFE, 0x00, 0x00
+                        # UTF32LE_BOM - 0xFF, 0xFE, 0x00, 0x00
                         ___converted="255, 254, 0, 0, "
                         ;;
                 *)
-                        # UTF32BE BOM (default) - 0x00, 0x00, 0xFE, 0xFF
+                        # UTF32BE_BOM (default) - 0x00, 0x00, 0xFE, 0xFF
                         ___converted="0, 0, 254, 255, "
                         ;;
                 esac

--- a/init/services/HestiaKERNEL/Unicode/To_UTF8_From_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/To_UTF8_From_Unicode.ps1
@@ -30,17 +30,19 @@ function HestiaKERNEL-To-UTF8-From-Unicode {
 
         # execute
         [System.Collections.Generic.List[byte]]$___converted = @()
+
+
+        # prefix BOM if requested
         if ($___bom -eq ${env:HestiaKERNEL_UTF_BOM}) {
-                # UTF-8 BOM - 0xEF, 0xBB, 0xBF
+                # UTF8_BOM - 0xEF, 0xBB, 0xBF
                 $null = $___converted.Add(0xEF)
                 $null = $___converted.Add(0xBB)
                 $null = $___converted.Add(0xBF)
         }
 
+
+        # convert to UTF-8 bytes list
         foreach ($___char in $___unicode) {
-                # convert to UTF-8 bytes list
-                # IMPORTANT NOTICE
-                #   (1) using single code-point algorithm (not the 2 16-bits).
                 if ($___char -lt 0x80) {
                         $null = $___converted.Add($___char)
                 } elseif ($___char -lt 0x800) {

--- a/init/services/HestiaKERNEL/Unicode/To_UTF8_From_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/To_UTF8_From_Unicode.sh
@@ -30,11 +30,16 @@ HestiaKERNEL_To_UTF8_From_Unicode() {
 
         # execute
         ___converted=""
+
+
+        # prefix BOM if requested
         if [ "$2" = "$HestiaKERNEL_UTF_BOM" ]; then
-                # UTF-8 BOM - 0xEF, 0xBB, 0xBF
-                ___converted="239, 187, 191"
+                # UTF8_BOM - 0xEF, 0xBB, 0xBF
+                ___converted="239, 187, 191, "
         fi
 
+
+        # convert to UTF-8 bytes list
         ___content="$1"
         while [ ! "$___content" = "" ]; do
                 # get current character decimal
@@ -44,10 +49,6 @@ HestiaKERNEL_To_UTF8_From_Unicode() {
                         ___content="${___content#, }"
                 fi
 
-
-                # convert to UTF-8 bytes list
-                # IMPORTANT NOTICE
-                #   (1) using single code-point algorithm (not the 2 16-bits).
                 if [ $___char -lt 200 ]; then
                         # char < 0x80
                         ___converted="${___converted}$(printf -- "%d" "$___char"), "


### PR DESCRIPTION
There were some minor performance bugs from To_UTF8_From_Unicode primitive function. Hence, let's fix it.

This patch fixes To_UTF8_From_Unicode primitive function bug in init/ directory.