### PR TITLE
init: fixed To_Lowercase_String primitive function bug

### DIFF
--- a/init/services/HestiaKERNEL/String/To_Lowercase_String.sh
+++ b/init/services/HestiaKERNEL/String/To_Lowercase_String.sh
@@ -50,5 +50,6 @@ HestiaKERNEL_To_Lowercase_String() {
 
 
         # report status
+        printf -- "%s" "$___content"
         return $HestiaKERNEL_ERROR_OK
 }


### PR DESCRIPTION
There were some minor performance bugs from To_Lowercase_String primitive function. Hence, let's fix it.

This patch fixes To_Lowercase_String primitive function bug in init/ directory.