### PR TITLE
init: fixed Trim_Prefix_String primitive function bug

### DIFF
--- a/init/services/HestiaKERNEL/String/Trim_Prefix_String.ps1
+++ b/init/services/HestiaKERNEL/String/Trim_Prefix_String.ps1
@@ -43,9 +43,6 @@ function HestiaKERNEL-Trim-Prefix-String {
         }
 
         $___content = HestiaKERNEL-Trim-Prefix-Unicode $___content $___chars
-        if ($___content.Length -eq 0) {
-                return $___input
-        }
 
 
         # report status

--- a/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.ps1
@@ -44,5 +44,5 @@ function HestiaKERNEL-Trim-Prefix-Unicode {
 
 
         # report status
-        return [uint32[]]$___content_unicode[$___index..($___content_unicode.Length - 1)]
+        return [uint32[]]$___content_unicode[$___index..($___content_unicode.Length)]
 }

--- a/init/services/HestiaKERNEL/Unicode/Trim_Suffix_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Suffix_Unicode.ps1
@@ -44,6 +44,11 @@ function HestiaKERNEL-Trim-Suffix-Unicode {
                 $___index -= 1
         }
 
+        if ($___index -le 0) {
+                return [uint32[]]@()
+        }
+        $___index += 1
+
 
         # report status
         return [uint32[]]$___content_unicode[0..$___index]


### PR DESCRIPTION
There were some minor performance bugs from Trim_Prefix_String primitive function. Hence, let's fix it.

This patch fixes Trim_Prefix_String primitive function bug in init/ directory.