### PR TITLE
init: fixed Trim_Left_String primitive function bug

### DIFF
--- a/init/services/HestiaKERNEL/String/Trim_Left_String.ps1
+++ b/init/services/HestiaKERNEL/String/Trim_Left_String.ps1
@@ -43,9 +43,6 @@ function HestiaKERNEL-Trim-Left-String {
         }
 
         $___content = HestiaKERNEL-Trim-Left-Unicode $___content $___chars
-        if ($___content.Length -eq 0) {
-                return $___input
-        }
 
 
         # report status

--- a/init/services/HestiaKERNEL/String/Trim_Left_String.sh
+++ b/init/services/HestiaKERNEL/String/Trim_Left_String.sh
@@ -48,16 +48,7 @@ HestiaKERNEL_Trim_Left_String() {
         fi
 
         ___content="$(HestiaKERNEL_Trim_Left_Unicode "$___content" "$___chars")"
-        if [ "$___content" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_BAD_EXEC
-        fi
-
         ___content="$(HestiaKERNEL_To_String_From_Unicode "$___content")"
-        if [ "$___content" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_BAD_EXEC
-        fi
         printf -- "%s" "$___content"
 
 

--- a/init/services/HestiaKERNEL/Unicode/Trim_Left_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Left_Unicode.sh
@@ -33,12 +33,8 @@ HestiaKERNEL_Trim_Left_Unicode() {
 
 
         # execute
-        ## IMPORTANT NOTICE
-        ## POSIX Shell's UNIX regex cannot recognize anything outside Latin-1
-        ## script. Therefore, manual algorithmic handling is required.
         ___content_unicode="$1"
         ___charset_unicode="$2"
-        ___converted=""
         while [ ! "$___content_unicode" = "" ]; do
                 # get current character
                 ___current="${___content_unicode%%, *}"
@@ -50,7 +46,7 @@ HestiaKERNEL_Trim_Left_Unicode() {
 
                 # get char from charset character
                 ___charset_list="$___charset_unicode"
-                ___mismatched=0
+                ___mismatched=0 ## assume mismatched by default
                 while [ ! "$___charset_list" = "" ]; do
                         ___char="${___charset_list%%, *}"
                         ___charset_list="${___charset_list#"$___char"}"
@@ -68,13 +64,13 @@ HestiaKERNEL_Trim_Left_Unicode() {
 
                 # It's a mismatch - append the rest and bail out
                 if [ $___mismatched -eq 0 ]; then
-                        ___converted="${___current}, ${___content_unicode}"
+                        ___content_unicode="${___current}, ${___content_unicode}"
                         break
                 fi
         done
 
 
         # report status
-        printf -- "%s" "${___converted%, }"
+        printf -- "%s" "${___content_unicode%, }"
         return $HestiaKERNEL_ERROR_OK
 }

--- a/init/services/HestiaKERNEL/Unicode/Trim_Right_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Right_Unicode.sh
@@ -34,7 +34,6 @@ HestiaKERNEL_Trim_Right_Unicode() {
         # execute
         ___content_unicode="$1"
         ___charset_unicode="$2"
-        ___converted=""
         while [ ! "$___content_unicode" = "" ]; do
                 # get current character
                 ___current="${___content_unicode##*, }"


### PR DESCRIPTION
There were some minor performance bugs from Trim_Left_String primitive function. Hence, let's fix it.

This patch fixes Trim_Left_String primitive function bug in init/ directory.