### PR TITLE
init: intensified trim_whitespace functions testing

### DIFF
--- a/init/services/HestiaKERNEL/Unicode/Trim_Whitespace_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Whitespace_Unicode.ps1
@@ -53,7 +53,7 @@ function HestiaKERNEL-Trim-Whitespace-Unicode {
 
                         # stop the scan if mismatched
                         if ($(HestiaKERNEL-Is-Whitespace-Unicode $___current) -ne ${env:HestiaKERNEL_ERROR_OK}) {
-                                $___scan_left = 1
+                                $___scan_right = 1
                         } else {
                                 $___index_right -= 1
                         }

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -118,6 +118,7 @@ Write-Host "|$(HestiaKERNEL-Trim-Whitespace-String '')|"
 Write-Host "|$(HestiaKERNEL-Trim-Whitespace-String "    ")|"
 Write-Host "|$(HestiaKERNEL-Trim-Whitespace-String "    e你feeeff你你aerg aegE你F    ")|"
 Write-Host "|$(HestiaKERNEL-Trim-Whitespace-String "e你feeeff你你aerg aegE你F    ")|"
+Write-Host "|$(HestiaKERNEL-Trim-Whitespace-String "    e你feeeff你你aerg aegE你F")|"
 Write-Host "----"
 
 Write-Host "---- Trim_Whitespace_Left_String ----"

--- a/init/start.sh
+++ b/init/start.sh
@@ -108,6 +108,7 @@ LIBS_HESTIA="${LIBS_UPSCALER}/services"
 1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_String "    ")"
 1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_String "    e你feeeff你你aerg aegE你F    ")"
 1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_String "e你feeeff你你aerg aegE你F    ")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Trim_Whitespace_String "    e你feeeff你你aerg aegE你F")"
 1>&2 printf -- "----\n"
 
 1>&2 printf -- "---- Trim_Whitespace_Left_String ----\n"


### PR DESCRIPTION
To make sure we want a reliable implementations before proceeding to port any functional functions, we have to make trim_Whitespace functions to behave as it is with strict testing. Hence, let's do this.

This patch intensify trim_whitespace functions testing in init/ directory.