### PR TITLE
init: optimized all String and Unicode primitive functions

### DIFF
--- a/init/services/HestiaKERNEL/String/Get_First_Character.ps1
+++ b/init/services/HestiaKERNEL/String/Get_First_Character.ps1
@@ -35,9 +35,6 @@ function HestiaKERNEL-Get-First-Character {
         }
 
         $___unicode = HestiaKERNEL-Get-First-Unicode $___unicodes
-        if ($___unicode -eq ${env:HestiaKERNEL_UNICODE_ERROR}) {
-                return ""
-        }
 
 
         # execute

--- a/init/services/HestiaKERNEL/String/Get_First_Character.sh
+++ b/init/services/HestiaKERNEL/String/Get_First_Character.sh
@@ -37,11 +37,6 @@ HestiaKERNEL_Get_First_Character() {
         fi
 
         ___unicode="$(HestiaKERNEL_Get_First_Unicode "$___unicodes")"
-        if [ "$___unicode" = "${HestiaKERNEL_UNICODE_ERROR}" ]; then
-                printf -- ""
-                return $HestiaKERNEL_ERROR_DATA_INVALID
-        fi
-
         printf -- "%s" "$(HestiaKERNEL_To_String_From_Unicode "$___unicode")"
         if [ $? -ne $HestiaKERNEL_ERROR_OK ]; then
                 return $HestiaKERNEL_ERROR_BAD_EXEC

--- a/init/services/HestiaKERNEL/String/Get_Last_Character.ps1
+++ b/init/services/HestiaKERNEL/String/Get_Last_Character.ps1
@@ -35,9 +35,6 @@ function HestiaKERNEL-Get-Last-Character {
         }
 
         $___unicode = HestiaKERNEL-Get-Last-Unicode $___unicodes
-        if ($___unicode -eq ${env:HestiaKERNEL_UNICODE_ERROR}) {
-                return ""
-        }
 
 
         # execute

--- a/init/services/HestiaKERNEL/String/Get_Last_Character.sh
+++ b/init/services/HestiaKERNEL/String/Get_Last_Character.sh
@@ -37,11 +37,6 @@ HestiaKERNEL_Get_Last_Character() {
         fi
 
         ___unicode="$(HestiaKERNEL_Get_Last_Unicode "$___unicodes")"
-        if [ "$___unicode" = "${HestiaKERNEL_UNICODE_ERROR}" ]; then
-                printf -- ""
-                return $HestiaKERNEL_ERROR_DATA_INVALID
-        fi
-
         printf -- "%s" "$(HestiaKERNEL_To_String_From_Unicode "$___unicode")"
         if [ $? -ne $HestiaKERNEL_ERROR_OK ]; then
                 return $HestiaKERNEL_ERROR_BAD_EXEC


### PR DESCRIPTION
Since the existing primitive functions for String and Unicode data types can be cascading, we should optimize them now before propogating further. Hence, let's do this.

This patch opmitizes all String and Unicode primitive functions in init/ directory.