### PR TITLE
init: backported changes to Trim_Prefix_* primitive functions

### DIFF
--- a/init/services/HestiaKERNEL/String/Index_Left_String.sh
+++ b/init/services/HestiaKERNEL/String/Index_Left_String.sh
@@ -9,7 +9,6 @@
 #
 # You MUST ensure any interaction with the content STRICTLY COMPLIES with
 # the permissions and limitations set forth in the license.
-. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Index_Left_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/To_Unicode_From_String.sh"
 

--- a/init/services/HestiaKERNEL/String/Trim_Prefix_String.ps1
+++ b/init/services/HestiaKERNEL/String/Trim_Prefix_String.ps1
@@ -18,30 +18,13 @@
 function HestiaKERNEL-Trim-Prefix-String {
         param (
                 [string]$___input,
-                [string]$___prefix
+                [string]$___target
         )
-
-
-        # validate input
-        if (
-                ($___input -eq "") -or
-                ($___prefix -eq "")
-        ) {
-                return $___input
-        }
 
 
         # execute
         $___content = HestiaKERNEL-To-Unicode-From-String $___input
-        if ($___content.Length -eq 0) {
-                return $___input
-        }
-
-        $___chars = HestiaKERNEL-To-Unicode-From-String $___prefix
-        if ($___chars.Length -eq 0) {
-                return $___input
-        }
-
+        $___chars = HestiaKERNEL-To-Unicode-From-String $___target
         $___content = HestiaKERNEL-Trim-Prefix-Unicode $___content $___chars
 
 

--- a/init/services/HestiaKERNEL/String/Trim_Prefix_String.sh
+++ b/init/services/HestiaKERNEL/String/Trim_Prefix_String.sh
@@ -9,7 +9,6 @@
 #
 # You MUST ensure any interaction with the content STRICTLY COMPLIES with
 # the permissions and limitations set forth in the license.
-. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/String/To_String_From_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/To_Unicode_From_String.sh"
@@ -19,39 +18,16 @@
 
 HestiaKERNEL_Trim_Prefix_String() {
         #___input="$1"
-        #___prefix="$2"
-
-
-        # validate input
-        if [ "$1" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
-        fi
-
-        if [ "$2" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_DATA_EMPTY
-        fi
+        #___target="$2"
 
 
         # execute
         ___content="$(HestiaKERNEL_To_Unicode_From_String "$1")"
-        if [ "$___content" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_DATA_INVALID
-        fi
-
         ___chars="$(HestiaKERNEL_To_Unicode_From_String "$2")"
-        if [ "$___chars" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_DATA_INVALID
-        fi
-
         ___content="$(HestiaKERNEL_Trim_Prefix_Unicode "$___content" "$___chars")"
-        ___content="$(HestiaKERNEL_To_String_From_Unicode "$___content")"
-        printf -- "%s" "$___content"
+        printf -- "%s" "$(HestiaKERNEL_To_String_From_Unicode "$___content")"
 
 
         # report status
-        return $HestiaKERNEL_ERROR_OK
+        return $?
 }

--- a/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.ps1
@@ -16,28 +16,28 @@
 function HestiaKERNEL-Trim-Prefix-Unicode {
         param (
                 [uint32[]]$___content_unicode,
-                [uint32[]]$___prefix_unicode
+                [uint32[]]$___target_unicode
         )
 
 
         # validate input
         if (
                 ($(HestiaKERNEL-Is-Unicode $___content_unicode) -ne ${env:HestiaKERNEL_ERROR_OK}) -or
-                ($(HestiaKERNEL-Is-Unicode $___prefix_unicode) -ne ${env:HestiaKERNEL_ERROR_OK})
+                ($(HestiaKERNEL-Is-Unicode $___target_unicode) -ne ${env:HestiaKERNEL_ERROR_OK})
         ) {
                 return $___content_unicode
         }
 
-        if ($___prefix_unicode.Length -gt $___content_unicode.Length) {
+        if ($___target_unicode.Length -gt $___content_unicode.Length) {
                 return $___content_unicode
         }
 
 
         # execute
-        $___index = $___prefix_unicode.Length
+        $___index = $___target_unicode.Length
         for ($i = 0; $i -le $___index - 1; $i++) {
                 # bail if mismatched
-                if ($___content_unicode[$i] -ne $___prefix_unicode[$i]) {
+                if ($___content_unicode[$i] -ne $___target_unicode[$i]) {
                         return $___content_unicode
                 }
         }

--- a/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Prefix_Unicode.sh
@@ -17,7 +17,7 @@
 
 HestiaKERNEL_Trim_Prefix_Unicode() {
         #___content_unicode="$1"
-        #___prefix_unicode="$2"
+        #___target_unicode="$2"
 
 
         # validate input
@@ -34,8 +34,8 @@ HestiaKERNEL_Trim_Prefix_Unicode() {
 
         # execute
         ___content_unicode="$1"
-        ___prefix_unicode="$2"
-        while [ ! "$___prefix_unicode" = "" ]; do
+        ___target_unicode="$2"
+        while [ ! "$___target_unicode" = "" ]; do
                 # get current character
                 ___current="${___content_unicode%%, *}"
                 ___content_unicode="${___content_unicode#"$___current"}"
@@ -45,16 +45,16 @@ HestiaKERNEL_Trim_Prefix_Unicode() {
 
 
                 # get target character
-                ___target="${___prefix_unicode%%, *}"
-                ___prefix_unicode="${___prefix_unicode#"$___target"}"
-                if [ "${___prefix_unicode%"${___prefix_unicode#?}"}" = "," ]; then
-                        ___prefix_unicode="${___prefix_unicode#, }"
+                ___target="${___target_unicode%%, *}"
+                ___target_unicode="${___target_unicode#"$___target"}"
+                if [ "${___target_unicode%"${___target_unicode#?}"}" = "," ]; then
+                        ___target_unicode="${___target_unicode#, }"
                 fi
 
 
                 # bail if mismatched
                 if [ "$___current" != "$___target" ] ||
-                        ([ "$___content_unicode" = "" ] && [ ! "$___prefix_unicode" = "" ]); then
+                        ([ "$___content_unicode" = "" ] && [ ! "$___target_unicode" = "" ]); then
                         printf -- "%s" "$1"
                         return $HestiaKERNEL_ERROR_OK
                 fi


### PR DESCRIPTION
There were some new optimization discovered when implementing Index_Left_{String,Unicode} functions. Hence, let's backport those changes back to its predecessor Trim_Prefix_{String,Unicode}.

This patch backports changes to Trim_Prefix_{String,Unicode} primitive functions in init/ directory.