### PR TITLE
init: backported changes to Trim_Left_* primitive functions

### DIFF
--- a/init/services/HestiaKERNEL/String/Trim_Left_String.ps1
+++ b/init/services/HestiaKERNEL/String/Trim_Left_String.ps1
@@ -18,30 +18,13 @@
 function HestiaKERNEL-Trim-Left-String {
         param (
                 [string]$___input,
-                [string]$___charset
+                [string]$___target
         )
-
-
-        # validate input
-        if (
-                ($___input -eq "") -or
-                ($___charset -eq "")
-        ) {
-                return $___input
-        }
 
 
         # execute
         $___content = HestiaKERNEL-To-Unicode-From-String $___input
-        if ($___content.Length -eq 0) {
-                return $___input
-        }
-
-        $___chars = HestiaKERNEL-To-Unicode-From-String $___charset
-        if ($___chars.Length -eq 0) {
-                return $___input
-        }
-
+        $___chars = HestiaKERNEL-To-Unicode-From-String $___target
         $___content = HestiaKERNEL-Trim-Left-Unicode $___content $___chars
 
 

--- a/init/services/HestiaKERNEL/String/Trim_Left_String.sh
+++ b/init/services/HestiaKERNEL/String/Trim_Left_String.sh
@@ -9,7 +9,6 @@
 #
 # You MUST ensure any interaction with the content STRICTLY COMPLIES with
 # the permissions and limitations set forth in the license.
-. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/String/To_String_From_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Trim_Left_Unicode.sh"
 . "${LIBS_HESTIA}/HestiaKERNEL/Unicode/To_Unicode_From_String.sh"
@@ -19,39 +18,16 @@
 
 HestiaKERNEL_Trim_Left_String() {
         #___content="$1"
-        #___charset="$2"
-
-
-        # validate input
-        if [ "$1" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
-        fi
-
-        if [ "$2" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_DATA_EMPTY
-        fi
+        #___target="$2"
 
 
         # execute
         ___content="$(HestiaKERNEL_To_Unicode_From_String "$1")"
-        if [ "$___content" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_DATA_INVALID
-        fi
-
         ___chars="$(HestiaKERNEL_To_Unicode_From_String "$2")"
-        if [ "$___chars" = "" ]; then
-                printf -- "%s" "$1"
-                return $HestiaKERNEL_ERROR_DATA_INVALID
-        fi
-
         ___content="$(HestiaKERNEL_Trim_Left_Unicode "$___content" "$___chars")"
-        ___content="$(HestiaKERNEL_To_String_From_Unicode "$___content")"
-        printf -- "%s" "$___content"
+        printf -- "%s" "$(HestiaKERNEL_To_String_From_Unicode "$___content")"
 
 
         # report status
-        return $HestiaKERNEL_ERROR_OK
+        return $?
 }

--- a/init/services/HestiaKERNEL/Unicode/Trim_Left_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Left_Unicode.ps1
@@ -16,14 +16,14 @@
 function HestiaKERNEL-Trim-Left-Unicode {
         param (
                 [uint32[]]$___content_unicode,
-                [uint32[]]$___charset_unicode
+                [uint32[]]$___target_unicode
         )
 
 
         # validate input
         if (
                 ($(HestiaKERNEL-Is-Unicode $___content_unicode) -ne ${env:HestiaKERNEL_ERROR_OK}) -or
-                ($(HestiaKERNEL-Is-Unicode $___charset_unicode) -ne ${env:HestiaKERNEL_ERROR_OK})
+                ($(HestiaKERNEL-Is-Unicode $___target_unicode) -ne ${env:HestiaKERNEL_ERROR_OK})
         ) {
                 return $___content_unicode
         }
@@ -45,7 +45,7 @@ function HestiaKERNEL-Trim-Left-Unicode {
 
 
                 # scan character from given charset
-                foreach ($___char in $___charset_unicode) {
+                foreach ($___char in $___target_unicode) {
                         if ($___current -eq $___char) {
                                 continue scan_unicode # exit early from O(m^2) timing ASAP
                         }

--- a/init/services/HestiaKERNEL/Unicode/Trim_Left_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/Trim_Left_Unicode.sh
@@ -17,7 +17,7 @@
 
 HestiaKERNEL_Trim_Left_Unicode() {
         #___content_unicode="$1"
-        #___charset_unicode="$2"
+        #___target_unicode="$2"
 
 
         # validate input
@@ -34,7 +34,6 @@ HestiaKERNEL_Trim_Left_Unicode() {
 
         # execute
         ___content_unicode="$1"
-        ___charset_unicode="$2"
         while [ ! "$___content_unicode" = "" ]; do
                 # get current character
                 ___current="${___content_unicode%%, *}"
@@ -44,18 +43,18 @@ HestiaKERNEL_Trim_Left_Unicode() {
                 fi
 
 
-                # get char from charset character
-                ___charset_list="$___charset_unicode"
+                # get char from target character
+                ___target_unicode="$2"
                 ___mismatched=0 ## assume mismatched by default
-                while [ ! "$___charset_list" = "" ]; do
-                        ___char="${___charset_list%%, *}"
-                        ___charset_list="${___charset_list#"$___char"}"
-                        if [ "${___charset_list%"${___charset_list#?}"}" = "," ]; then
-                                ___charset_list="${___charset_list#, }"
+                while [ ! "$___target_unicode" = "" ]; do
+                        ___char="${___target_unicode%%, *}"
+                        ___target_unicode="${___target_unicode#"$___char"}"
+                        if [ "${___target_unicode%"${___target_unicode#?}"}" = "," ]; then
+                                ___target_unicode="${___target_unicode#, }"
                         fi
 
                         if [ "$___current" = "$___char" ]; then
-                                ___charset_list=""
+                                ___target_unicode=""
                                 ___mismatched=1
                                 break # exit early from O(m^2) timing ASAP
                         fi


### PR DESCRIPTION
There were some new optimization discovered when implementing Index_Left_{String,Unicode} functions. Hence, let's backport those changes back to its predecessor Trim_Suffix_{String,Unicode}.

This patch backports changes to Trim_Left_{String,Unicode} primitive functions in init/ directory.