### PR TITLE
init: ported Replace_Left_{String,Unicode} primitive function

### DIFF
--- a/init/services/HestiaKERNEL/String/Replace_Left_String.ps1
+++ b/init/services/HestiaKERNEL/String/Replace_Left_String.ps1
@@ -1,0 +1,41 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\String\To_String_From_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Replace_Left_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\To_Unicode_From_String.ps1"
+
+
+
+
+function HestiaKERNEL-Replace-Left-String {
+        param (
+                [string]$___input,
+                [string]$___from,
+                [string]$___to,
+                [int32]$___count,
+                [int32]$___ignore
+        )
+
+
+        # execute
+        $___content = HestiaKERNEL-To-Unicode-From-String $___input
+        $___chars_from = HestiaKERNEL-To-Unicode-From-String $___from
+        $___chars_to = HestiaKERNEL-To-Unicode-From-String $___to
+        $___content = HestiaKERNEL-Replace-Left-Unicode $___content `
+                                                        $___chars_from `
+                                                        $___chars_to `
+                                                        $___count `
+                                                        $___ignore
+
+
+        # report status
+        return HestiaKERNEL-To-String-From-Unicode $___content
+}

--- a/init/services/HestiaKERNEL/String/Replace_Left_String.sh
+++ b/init/services/HestiaKERNEL/String/Replace_Left_String.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/String/To_String_From_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Replace_Left_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/To_Unicode_From_String.sh"
+
+
+
+
+HestiaKERNEL_Replace_Left_String() {
+        #___input="$1"
+        #___from="$2"
+        #___to="$3"
+        #___count="$4"
+        #___ignore="$5"
+
+
+        # execute
+        ___content="$(HestiaKERNEL_To_Unicode_From_String "$1")"
+        ___chars_from="$(HestiaKERNEL_To_Unicode_From_String "$2")"
+        ___chars_to="$(HestiaKERNEL_To_Unicode_From_String "$3")"
+        ___content="$(HestiaKERNEL_Replace_Left_Unicode "$___content" \
+                                                        "$___chars_from" \
+                                                        "$___chars_to" \
+                                                        "$4" \
+                                                        "$5" \
+        )"
+
+
+        # report status
+        printf -- "%b" "$(HestiaKERNEL_To_String_From_Unicode "$___content")"
+        return $?
+}

--- a/init/services/HestiaKERNEL/Unicode/Replace_Left_Unicode.ps1
+++ b/init/services/HestiaKERNEL/Unicode/Replace_Left_Unicode.ps1
@@ -1,0 +1,145 @@
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Unicode\Is_Unicode.ps1"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\Number\Is_Number.ps1"
+
+
+
+
+function HestiaKERNEL-Replace-Left-Unicode {
+        param (
+                [uint32[]]$___content_unicode,
+                [uint32[]]$___from_unicode,
+                [uint32[]]$___to_unicode,
+                [int32]$___count,
+                [int32]$___ignore
+        )
+
+
+        # validate input
+        if (
+                ($(HestiaKERNEL-Is-Unicode $___content_unicode) -ne ${env:HestiaKERNEL_ERROR_OK}) -or
+                ($(HestiaKERNEL-Is-Unicode $___from_unicode) -ne ${env:HestiaKERNEL_ERROR_OK})
+        ) {
+                return $___content_unicode
+        }
+
+        if ($___to_unicode.Length -gt 0) {
+                if ($(HestiaKERNEL-Is-Unicode $___to_unicode) -ne ${env:HestiaKERNEL_ERROR_OK}) {
+                        return [uint32[]]@()
+                }
+        }
+
+        if (
+                ("${___count}" -eq "") -or
+                ($___count -le 0)
+        ) {
+                $___count = -1
+        }
+
+        if (
+                ("${___ignore}" -eq "") -or
+                ($___ignore -le 0)
+        ) {
+                $___ignore = -1
+        }
+
+        if ($___target_unicode.Length -gt $___content_unicode.Length) {
+                return $___content_unicode
+        }
+
+
+        # execute
+        [System.Collections.Generic.List[uint32]]$___converted = @()
+        [System.Collections.Generic.List[uint32]]$___buffer = @()
+        $___from_index = 0
+        $___from_length = $___from_unicode.Length - 1
+        $___is_replacing = 0
+        for ($___index = 0; $___index -le $___content_unicode.Length - 1; $___index++) {
+                # get current character
+                $___current = $___content_unicode[$___index]
+
+
+                # get target character
+                $___from = $___from_unicode[$___from_index]
+                $___from_index += 1
+
+
+                # bail if mismatched
+                if ($___current -ne $___from) {
+                        $___from_index = 0
+
+                        if ($___buffer.Length -gt 0) {
+                                foreach ($___char in $___buffer) {
+                                        $___converted.Add($___char)
+                                }
+                                [System.Collections.Generic.List[uint32]]$___buffer = @()
+                        }
+
+                        $___converted.Add($___current)
+                        continue
+                }
+
+
+                # it's a match - save to buffer if the scan is still ongoing
+                if ($___from_index -le $___from_length) {
+                        $___buffer.Add($___current)
+                        continue
+                }
+
+
+                # complete match - perform replacement
+                if ($___ignore -le 0) {
+                        foreach ($___char in $___to_unicode) {
+                                $___converted.Add($___char)
+                        }
+
+                        if ($___count -gt 0) {
+                                $___count -= 1
+                                if ($___count -le 0) {
+                                        $___is_replacing = 1
+
+                                        if ($___buffer.Length -gt 0) {
+                                                foreach ($___char in $___buffer) {
+                                                        $___converted.Add($___char)
+                                                }
+                                                [System.Collections.Generic.List[uint32]]$___buffer = @()
+                                        }
+
+                                        continue
+                                }
+                        }
+                } else {
+                        if ($___buffer.Length -gt 0) {
+                                foreach ($___char in $___buffer) {
+                                        $___converted.Add($___char)
+                                }
+                        }
+
+                        $___converted.Add($___current)
+                        $___ignore -= 1
+                }
+
+                [System.Collections.Generic.List[uint32]]$___buffer = @()
+                $___from_index = 0
+        }
+
+        if ($___buffer.Length -gt 0) {
+                foreach ($___char in $___buffer) {
+                        $___converted.Add($___char)
+                }
+                [System.Collections.Generic.List[uint32]]$___buffer = @()
+        }
+
+
+        # report status
+        return [uint32[]]$___converted
+}

--- a/init/services/HestiaKERNEL/Unicode/Replace_Left_Unicode.sh
+++ b/init/services/HestiaKERNEL/Unicode/Replace_Left_Unicode.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# Copyright 2024 (Holloway) Chew, Kean Ho <hello@hollowaykeanho.com>
+#
+#
+# Licensed under (Holloway) Chew, Kean Ho’s Liberal License (the "License").
+# You must comply with the license to use the content. Get the License at:
+#
+#                 https://doi.org/10.5281/zenodo.13770769
+#
+# You MUST ensure any interaction with the content STRICTLY COMPLIES with
+# the permissions and limitations set forth in the license.
+. "${LIBS_HESTIA}/HestiaKERNEL/Errors/Error_Codes.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Unicode/Is_Unicode.sh"
+. "${LIBS_HESTIA}/HestiaKERNEL/Number/Is_Number.sh"
+
+
+
+
+HestiaKERNEL_Replace_Left_Unicode() {
+        #___content_unicode="$1"
+        #___from_unicode="$2"
+        #___to_unicode="$3"
+        #___count="$4"
+        #___ignore="$5"
+
+
+        # validate input
+        if [ $(HestiaKERNEL_Is_Unicode "$1") -ne $HestiaKERNEL_ERROR_OK ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_ENTITY_EMPTY
+        fi
+
+        if [ $(HestiaKERNEL_Is_Unicode "$2") -ne $HestiaKERNEL_ERROR_OK ]; then
+                printf -- "%s" "$1"
+                return $HestiaKERNEL_ERROR_DATA_EMPTY
+        fi
+
+        if [ ! "$3" = "" ]; then
+                if [ $(HestiaKERNEL_Is_Unicode "$3") -ne $HestiaKERNEL_ERROR_OK ]; then
+                        printf -- "" ""
+                        return $HestiaKERNEL_ERROR_DATA_INVALID
+                fi
+        fi
+
+        ___count=-1
+        if [ $(HestiaKERNEL_Is_Number "$4") -eq $HestiaKERNEL_ERROR_OK ]; then
+                ___count="$4"
+        fi
+
+        ___ignore=-1
+        if [ $(HestiaKERNEL_Is_Number "$5") -eq $HestiaKERNEL_ERROR_OK ]; then
+                ___ignore="$5"
+        fi
+
+
+        # execute
+        ___converted=""
+        ___buffer=""
+        ___content_unicode="$1"
+        ___from_unicode="$2"
+        ___to_unicode="$3"
+        ___is_replacing=0
+        while [ ! "$___content_unicode" = "" ]; do
+                # get current character
+                ___current="${___content_unicode%%, *}"
+                ___content_unicode="${___content_unicode#"$___current"}"
+                if [ "${___content_unicode%"${___content_unicode#?}"}" = "," ]; then
+                        ___content_unicode="${___content_unicode#, }"
+                fi
+
+                if [ $___is_replacing -ne 0 ]; then
+                        ___converted="${___converted}${___current}, "
+                        continue
+                fi
+
+
+                # get from character
+                ___from="${___from_unicode%%, *}"
+                ___from_unicode="${___from_unicode#"$___from"}"
+                if [ "${___from_unicode%"${___from_unicode#?}"}" = "," ]; then
+                        ___from_unicode="${___from_unicode#, }"
+                fi
+
+
+                # bail if mismatched
+                if [ ! "$___current" = "$___from" ]; then
+                        ___from_unicode="$2"
+
+                        if [ ! "$___buffer" = "" ]; then
+                                ___converted="${___converted}${___buffer%, }, "
+                                ___buffer=""
+                        fi
+
+                        ___converted="${___converted}${___current}, "
+                        continue
+                fi
+
+
+                # it's a match - save to buffer if the scan is still ongoing
+                if [ ! "$___from_unicode" = "" ]; then
+                        ___buffer="${___buffer}${___current}, "
+                        continue
+                fi
+
+
+                # complete match - perform replacement
+                if [ $___ignore -le 0 ]; then
+                        if [ ! "$___to_unicode" = "" ]; then
+                                ___converted="${___converted}${___to_unicode}, "
+                        fi
+
+                        if [ $___count -gt 0 ]; then
+                                ___count=$(($___count - 1))
+                                if [ $___count -le 0 ]; then
+                                        ___is_replacing=1
+
+                                        if [ ! "$___buffer" = "" ]; then
+                                                ___converted="${___converted}${___buffer%, }, "
+                                                ___buffer=""
+                                        fi
+
+                                        continue
+                                fi
+                        fi
+                else
+                        if [ ! "$___buffer" = "" ]; then
+                                ___converted="${___converted}${___buffer%, }, "
+                        fi
+
+                        ___converted="${___converted}${___current}, "
+                        ___ignore=$(($___ignore - 1))
+                fi
+
+                ___buffer=""
+                ___from_unicode="$2"
+        done
+
+        if [ ! "$___buffer" = "" ]; then
+                ___converted="${___converted}${___buffer%, }, "
+                ___buffer=""
+        fi
+
+
+        # report status
+        printf -- "%b" "${___converted%, }"
+        return $HestiaKERNEL_ERROR_OK
+}

--- a/init/start.ps1
+++ b/init/start.ps1
@@ -112,6 +112,47 @@ ${env:LIBS_HESTIA} = "${env:LIBS_UPSCALER}\services"
 . "${env:LIBS_UPSCALER}\services\i18n\report-success.ps1"
 
 ### TEST ZONE
+Write-Host "---- Replace-Left-String ----"
+. "${env:LIBS_HESTIA}\HestiaKERNEL\String\Replace_Left_String.ps1"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" '' '')|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String '' "e你f" "y我z")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String '' "e你a" "y我z")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String '' "e你f" '')|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String '' "e你a" '')|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" `
+                                                "e你feeeff你你aerg aegE你F" `
+                                                "y我z")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" `
+                                                "e你feeeff你你aerg aegE你F" `
+                                                '')|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你feeeff你你aerg aegE你F" )|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" `
+                                                "e你feeeff你你aerg aegE你FX" `
+                                                "y我z")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" `
+                                                "e你feeeff你你aerg aegE你FX" `
+                                                '')|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你feeeff你你aerg aegE你FX")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你a" "y我z")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你f" "y我z")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "a" "z")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "你" "我")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "z" "j")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "我" "他")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "y我z" "XXX")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "-1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "-1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "1" "1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "1" "1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "-1" "1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "-1" "1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "1" "-1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "1" "-1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "-1" "-1")|"
+Write-Host "|$(HestiaKERNEL-Replace-Left-String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "-1" "-1")|"
+
 Write-Host "---- Scan-String ----"
 . "${env:LIBS_HESTIA}\HestiaKERNEL\String\Scan_String.ps1"
 Write-Host "|$(HestiaKERNEL-Scan-String "e你feeeff你你aerg aegE你F" "a" "-1" "-1" "right")|"

--- a/init/start.sh
+++ b/init/start.sh
@@ -102,6 +102,51 @@ LIBS_HESTIA="${LIBS_UPSCALER}/services"
 . "${LIBS_UPSCALER}/services/i18n/report-success.sh"
 
 ### TEST ZONE
+1>&2 printf -- "---- Replace_Left_String ----\n"
+. "${LIBS_HESTIA}/HestiaKERNEL/String/Replace_Left_String.sh"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "" "")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "" "e你f" "y我z")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "" "e你a" "y我z")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "" "e你f" "")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "" "e你a" "")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" \
+                                                                "e你feeeff你你aerg aegE你F" \
+                                                                "y我z"
+                        )"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" \
+                                                                "e你feeeff你你aerg aegE你F" \
+                                                                ""
+                        )"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你feeeff你你aerg aegE你F")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" \
+                                                                "e你feeeff你你aerg aegE你FX" \
+                                                                "y我z"
+                        )"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" \
+                                                                "e你feeeff你你aerg aegE你FX" \
+                                                                ""
+                        )"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你feeeff你你aerg aegE你FX")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你a" "y我z")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你f" "y我z")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "a" "z")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "你" "我")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "z" "j")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "我" "他")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "y我z" "XXX")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "-1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "-1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "1" "1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "1" "1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "-1" "1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "-1" "1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "1" "-1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "1" "-1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你a" "y我z" "-1" "-1")"
+1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Replace_Left_String "e你feeeff你你aerg aegE你F" "e你f" "y我z" "-1" "-1")"
+
 1>&2 printf -- "---- Scan_String ----\n"
 . "${LIBS_HESTIA}/HestiaKERNEL/String/Scan_String.sh"
 1>&2 printf -- "|%s|\n" "$(HestiaKERNEL_Scan_String "e你feeeff你你aerg aegE你F" "a" "-1" "-1" "right")"


### PR DESCRIPTION
Since there are a number of level 1 libraries using the string function, we have to port its primitive ones into HestiaKERNEL library. Let's do this.

This patch ports Replace_Left_{String,Unicode} primitive function into HestiaKERNEL library into init/ directory.