### PR TITLE
Fix: handle source_file without slashes using dirname

### DIFF
--- a/init/unix.sh
+++ b/init/unix.sh
@@ -307,7 +307,7 @@ _check_io() {
         fi
 
         subject_name="${source_file##*/}"
-        subject_dir="${source_file%/*}"
+        subject_dir="$(dirname "$source_file")"
         subject_ext="${subject_name#*.}"
         subject_name="${subject_name%%.*}"
 


### PR DESCRIPTION
Fixes #97 

This patch replaces Bash parameter expansion `${source_file%/*}` with `dirname`, 
ensuring the script correctly handles file names without slashes (e.g., `test.png`). 
This makes the behavior more robust and POSIX-compliant, and resolves incorrect 
behavior when no slash is present in the path.